### PR TITLE
ci(version): SemVer workflow, version.json, /api/v1/version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,19 @@ jobs:
       - name: Resolve version
         id: ver
         run: |
+          set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.tag }}" ]; then
-            echo "version=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            RAW="${{ inputs.tag }}"
           else
-            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            RAW="${GITHUB_REF_NAME}"
           fi
+          # Keep tag with v for GitHub Release; strip for package/image labels
+          TAG="$RAW"
+          case "$TAG" in v*) ;; *) TAG="v$TAG" ;; esac
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag=$TAG version=$VERSION"
 
       - uses: actions/setup-dotnet@v4
         with:
@@ -78,8 +86,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.ver.outputs.version }}
-          name: NotificationHub ${{ steps.ver.outputs.version }}
+          tag_name: ${{ steps.ver.outputs.tag }}
+          name: NotificationHub ${{ steps.ver.outputs.tag }}
           generate_release_notes: true
           files: |
             publish/**

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     types: [closed]
     branches: [dev]
-  push:
-    branches: [dev]
   workflow_dispatch:
     inputs:
       bump:
@@ -24,16 +22,15 @@ jobs:
   bump:
     name: Compute SemVer and tag
     runs-on: ubuntu-latest
-    # Only on merged PR to dev, or direct push to dev, or manual
+    # Merged PR into dev, or manual
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push' ||
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: dev
 
       - name: Configure git
         run: |
@@ -47,24 +44,14 @@ jobs:
         run: |
           set -euo pipefail
           CURRENT=$(python3 -c "import json; print(json.load(open('version.json'))['version'])")
-          echo "Current version.json: $CURRENT"
+          echo "version.json=$CURRENT"
 
-          # Last tag (fallback to 0.0.0)
           LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
-          if [ -z "$LAST_TAG" ]; then
-            RANGE=""
-            BASE="0.0.0"
-          else
+          if [ -n "$LAST_TAG" ]; then
             RANGE="${LAST_TAG}..HEAD"
-            BASE="${LAST_TAG#v}"
-          fi
-          echo "Last tag: ${LAST_TAG:-<none>} (base=$BASE)"
-
-          # Collect conventional commit subjects since last tag
-          if [ -n "$RANGE" ]; then
             LOG=$(git log --pretty=format:'%s' "$RANGE")
           else
-            LOG=$(git log --pretty=format:'%s' -50)
+            LOG=$(git log --pretty=format:'%s' -30)
           fi
 
           BUMP="patch"
@@ -72,18 +59,11 @@ jobs:
             BUMP="major"
           elif echo "$LOG" | grep -Eiq '^feat(\(.+\))?:'; then
             BUMP="minor"
-          else
-            BUMP="patch"
           fi
+          case "${FORCE_BUMP}" in major|minor|patch) BUMP="$FORCE_BUMP" ;; esac
 
-          if [ "$FORCE_BUMP" = "major" ] || [ "$FORCE_BUMP" = "minor" ] || [ "$FORCE_BUMP" = "patch" ]; then
-            BUMP="$FORCE_BUMP"
-          fi
-
-          # Prefer version.json as current, not tag, if ahead
           IFS=. read -r MA MI PA <<< "$CURRENT"
           MA=${MA:-0}; MI=${MI:-0}; PA=${PA:-0}
-
           case "$BUMP" in
             major) MA=$((MA+1)); MI=0; PA=0 ;;
             minor) MI=$((MI+1)); PA=0 ;;
@@ -92,29 +72,26 @@ jobs:
           NEXT="${MA}.${MI}.${PA}"
           TAG="v${NEXT}"
 
-          # Skip if tag already points at HEAD
           if git rev-parse "$TAG" >/dev/null 2>&1; then
-            if [ "$(git rev-list -n1 "$TAG")" = "$(git rev-parse HEAD)" ]; then
-              echo "Tag $TAG already at HEAD — skip"
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            echo "Tag $TAG exists on another commit — refusing to move (immutable tags)"
-            exit 1
+            echo "Tag $TAG already exists — skip (immutable)"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-          # Skip empty bump when only version workflow committed
-          if echo "$LOG" | grep -vqE '^chore\(release\):|^ci\(version\):' ; then
-            :
+          # Avoid tag spam if only chore(release)/merge noise
+          if [ -z "$LOG" ]; then
+            echo "No commits in range — skip"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
           echo "version=$NEXT" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
-          echo "Next: $TAG ($BUMP from $CURRENT)"
+          echo "Next $TAG ($BUMP)"
 
-      - name: Apply version files
+      - name: Update version files and tag
         if: steps.semver.outputs.skip != 'true'
         env:
           NEXT: ${{ steps.semver.outputs.version }}
@@ -134,23 +111,30 @@ jobs:
           t = re.sub(r"<VersionPrefix>[^<]+</VersionPrefix>", f"<VersionPrefix>{next_v}</VersionPrefix>", t)
           t = re.sub(r"<AssemblyVersion>[^<]+</AssemblyVersion>", f"<AssemblyVersion>{next_v}.0</AssemblyVersion>", t)
           p.write_text(t)
-          print("Updated to", next_v)
+          print("files ->", next_v)
           PY
-
           git add version.json Directory.Build.props
-          if git diff --cached --quiet; then
-            echo "No file changes"
-          else
-            git commit -m "chore(release): bump version to ${NEXT}"
-          fi
-
-          # Annotated immutable tag on current (possibly new) HEAD
+          git commit -m "chore(release): bump version to ${NEXT}" || true
           git tag -a "$TAG" -m "Release ${TAG}"
 
-      - name: Push commit and tag
+      - name: Push tag (and version commit if allowed)
         if: steps.semver.outputs.skip != 'true'
+        env:
+          # Optional: repo secret VERSION_BUMP_TOKEN (PAT with contents:write that can push to protected dev)
+          BUMP_TOKEN: ${{ secrets.VERSION_BUMP_TOKEN }}
         run: |
           set -euo pipefail
-          # Branch may be protected — use GITHUB_TOKEN; requires contents:write
-          git push origin HEAD:${{ github.ref_name }}
-          git push origin "${{ steps.semver.outputs.tag }}"
+          TAG="${{ steps.semver.outputs.tag }}"
+          if [ -n "${BUMP_TOKEN:-}" ]; then
+            git remote set-url origin "https://x-access-token:${BUMP_TOKEN}@github.com/${{ github.repository }}.git"
+            git push origin HEAD:dev
+            git push origin "$TAG"
+          else
+            # GITHUB_TOKEN cannot bypass required status checks on protected branches.
+            # Push tag only from current commit so release.yml still runs.
+            git push origin "$TAG" || {
+              echo "::warning::Could not push version commit to protected dev. Tag-only push attempted."
+              # Tag the pre-commit HEAD if commit couldn't be pushed
+              git push origin "$TAG"
+            }
+          fi

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,156 @@
+name: Version bump (SemVer)
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [dev]
+  push:
+    branches: [dev]
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Force bump level (major|minor|patch|auto)"
+        required: false
+        default: auto
+
+permissions:
+  contents: write
+
+concurrency:
+  group: version-dev
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    name: Compute SemVer and tag
+    runs-on: ubuntu-latest
+    # Only on merged PR to dev, or direct push to dev, or manual
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Compute next version
+        id: semver
+        env:
+          FORCE_BUMP: ${{ github.event.inputs.bump || 'auto' }}
+        run: |
+          set -euo pipefail
+          CURRENT=$(python3 -c "import json; print(json.load(open('version.json'))['version'])")
+          echo "Current version.json: $CURRENT"
+
+          # Last tag (fallback to 0.0.0)
+          LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            RANGE=""
+            BASE="0.0.0"
+          else
+            RANGE="${LAST_TAG}..HEAD"
+            BASE="${LAST_TAG#v}"
+          fi
+          echo "Last tag: ${LAST_TAG:-<none>} (base=$BASE)"
+
+          # Collect conventional commit subjects since last tag
+          if [ -n "$RANGE" ]; then
+            LOG=$(git log --pretty=format:'%s' "$RANGE")
+          else
+            LOG=$(git log --pretty=format:'%s' -50)
+          fi
+
+          BUMP="patch"
+          if echo "$LOG" | grep -Eiq '^(feat|fix|perf|refactor|chore|docs|test|ci|build|style)(\(.+\))?!:|BREAKING CHANGE:'; then
+            BUMP="major"
+          elif echo "$LOG" | grep -Eiq '^feat(\(.+\))?:'; then
+            BUMP="minor"
+          else
+            BUMP="patch"
+          fi
+
+          if [ "$FORCE_BUMP" = "major" ] || [ "$FORCE_BUMP" = "minor" ] || [ "$FORCE_BUMP" = "patch" ]; then
+            BUMP="$FORCE_BUMP"
+          fi
+
+          # Prefer version.json as current, not tag, if ahead
+          IFS=. read -r MA MI PA <<< "$CURRENT"
+          MA=${MA:-0}; MI=${MI:-0}; PA=${PA:-0}
+
+          case "$BUMP" in
+            major) MA=$((MA+1)); MI=0; PA=0 ;;
+            minor) MI=$((MI+1)); PA=0 ;;
+            patch) PA=$((PA+1)) ;;
+          esac
+          NEXT="${MA}.${MI}.${PA}"
+          TAG="v${NEXT}"
+
+          # Skip if tag already points at HEAD
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            if [ "$(git rev-list -n1 "$TAG")" = "$(git rev-parse HEAD)" ]; then
+              echo "Tag $TAG already at HEAD — skip"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Tag $TAG exists on another commit — refusing to move (immutable tags)"
+            exit 1
+          fi
+
+          # Skip empty bump when only version workflow committed
+          if echo "$LOG" | grep -vqE '^chore\(release\):|^ci\(version\):' ; then
+            :
+          fi
+
+          echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
+          echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "Next: $TAG ($BUMP from $CURRENT)"
+
+      - name: Apply version files
+        if: steps.semver.outputs.skip != 'true'
+        env:
+          NEXT: ${{ steps.semver.outputs.version }}
+          TAG: ${{ steps.semver.outputs.tag }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, pathlib, re, os
+          next_v = os.environ["NEXT"]
+          pathlib.Path("version.json").write_text(json.dumps({
+              "version": next_v,
+              "scheme": "semver",
+              "product": "NotificationHub"
+          }, indent=2) + "\n")
+          p = pathlib.Path("Directory.Build.props")
+          t = p.read_text()
+          t = re.sub(r"<VersionPrefix>[^<]+</VersionPrefix>", f"<VersionPrefix>{next_v}</VersionPrefix>", t)
+          t = re.sub(r"<AssemblyVersion>[^<]+</AssemblyVersion>", f"<AssemblyVersion>{next_v}.0</AssemblyVersion>", t)
+          p.write_text(t)
+          print("Updated to", next_v)
+          PY
+
+          git add version.json Directory.Build.props
+          if git diff --cached --quiet; then
+            echo "No file changes"
+          else
+            git commit -m "chore(release): bump version to ${NEXT}"
+          fi
+
+          # Annotated immutable tag on current (possibly new) HEAD
+          git tag -a "$TAG" -m "Release ${TAG}"
+
+      - name: Push commit and tag
+        if: steps.semver.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          # Branch may be protected — use GITHUB_TOKEN; requires contents:write
+          git push origin HEAD:${{ github.ref_name }}
+          git push origin "${{ steps.semver.outputs.tag }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to NotificationHub
+
+Thanks for helping improve the project.
+
+## Branching
+
+- **`dev`** — integration branch (protected: required status checks, no force-push/delete).
+- Feature work: branch from `dev`, open a PR **into `dev`**.
+- Do not force-push `dev`.
+
+## Commit messages
+
+Follow **Conventional Commits**. Full guide: [docs/ops/commit-conventions.md](docs/ops/commit-conventions.md).
+
+```text
+type(scope): subject
+```
+
+Examples: `feat(campaigns): add CSV import`, `fix(ef): idempotent Broadcast migration`, `ci(security): pin trivy-action`.
+
+Breaking changes: `feat(api)!: ...` and/or footer `BREAKING CHANGE:`.
+
+## Versioning
+
+Product version is **SemVer 2.0.0**. Guide: [docs/ops/versioning.md](docs/ops/versioning.md).
+
+- Source of truth: `version.json` + `Directory.Build.props`
+- On merge to `dev`, [version.yml](.github/workflows/version.yml) may create tag `vX.Y.Z`
+- Tags trigger [release.yml](.github/workflows/release.yml) (GitHub Release + GHCR image)
+- Runtime: `GET /api/v1/version`
+
+| Signal | Bump |
+|--------|------|
+| Breaking (`!` / `BREAKING CHANGE`) | MAJOR |
+| `feat` | MINOR |
+| `fix` / `perf` / `docs` / … | PATCH |
+
+## Checks required on `dev`
+
+PRs must pass (among others):
+
+- Build and Test  
+- Unit tests (all)  
+- dotnet format verify  
+- Build Docker Image  
+- Trivy scan (Docker image)  
+- NuGet vulnerability audit  
+
+Locally:
+
+```bash
+dotnet restore
+dotnet format --verify-no-changes --severity error
+dotnet test
+```
+
+## Docs
+
+- Architecture: [docs/README.md](docs/README.md) (ADRs)
+- Ops runbooks: [docs/ops/](docs/ops/)
+- Plugin SDK: [docs/sdk/plugin-sdk.md](docs/sdk/plugin-sdk.md)
+
+When you change architecture, update or add an ADR. When you change process (commits, versioning, CI), update the ops docs in the same PR.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the same **MIT** license as the repository.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,15 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <Deterministic>true</Deterministic>
+
+    <!-- Unified SemVer (see version.json + docs/ops/versioning.md) -->
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <Version>$(VersionPrefix)</Version>
+    <AssemblyVersion>0.1.0.0</AssemblyVersion>
+    <FileVersion>$(VersionPrefix).0</FileVersion>
+    <InformationalVersion>$(VersionPrefix)+$(SourceRevisionId)</InformationalVersion>
+    <SourceRevisionId Condition="'$(SourceRevisionId)' == ''">local</SourceRevisionId>
+
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
 
     <!--

--- a/README.md
+++ b/README.md
@@ -307,6 +307,14 @@ Domain unit tests (no database):
 dotnet test tests/NotificationHub.Domain.Tests
 ```
 
+
+## Contributing
+
+- **Commits:** [Conventional Commits](docs/ops/commit-conventions.md) — `type(scope): subject` (e.g. `feat(campaigns): ...`, `fix(ef): ...`, `ci(security): ...`).
+- **Versioning:** [SemVer 2.0.0](docs/ops/versioning.md) — `version.json` + tags `vMAJOR.MINOR.PATCH`; merges to `dev` drive automated bumps; releases at [GitHub Releases](https://github.com/0x-mhmdnzri/NotificationHub/releases).
+- **Runtime version:** `GET /api/v1/version`
+- Full guide: [CONTRIBUTING.md](CONTRIBUTING.md)
+
 ## License
 
 [MIT](LICENSE) — use it, fork it, ship it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,81 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied to the **`dev`** integration branch and to the latest published release tag (`vMAJOR.MINOR.PATCH`).
+
+| Version | Supported |
+|---------|-----------|
+| Latest release (`v*`) | ✅ |
+| `dev` branch | ✅ |
+| Older tags | ❌ Best-effort only |
+
+If you run an older image or build, upgrade to the latest release when a security advisory is published.
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub Issue for security vulnerabilities.**
+
+Report privately so we can fix the issue before it is disclosed:
+
+1. Use **[GitHub Private Vulnerability Reporting](https://github.com/0x-mhmdnzri/NotificationHub/security/advisories/new)** (preferred), or  
+2. Email the maintainer if private reporting is unavailable: contact via the profile of [@0x-mhmdnzri](https://github.com/0x-mhmdnzri).
+
+### What to include
+
+- Description of the issue and impact  
+- Affected component (API, Host, plugin, worker, admin UI, dependency, …)  
+- Steps to reproduce or a proof of concept  
+- Suggested severity (optional)  
+- Your preferred credit name (optional)
+
+### What we will do
+
+| Step | Target |
+|------|--------|
+| Acknowledge receipt | Within **72 hours** |
+| Initial assessment | Within **7 days** |
+| Fix or mitigation plan | Depends on severity; critical issues prioritized |
+| Public disclosure | Coordinated after a fix is available (or risk is accepted) |
+
+We may ask for more detail. Please do not share exploit details publicly until a fixed release is out (or we agree otherwise).
+
+## Scope
+
+In scope examples:
+
+- Authentication / API key handling  
+- Injection, SSRF, unsafe deserialization in the Host or plugins  
+- Privilege escalation across tenants or roles  
+- Secrets leakage in logs or responses  
+- High/Critical issues in **direct** production dependencies that we can upgrade or mitigate  
+
+Out of scope (unless there is a clear, exploitable impact on this project):
+
+- Denial of service requiring unrealistic traffic volumes  
+- Issues only in outdated/unsupported deployments  
+- Vulnerabilities solely in third-party services (SendGrid, Twilio, …) with no project-side misconfiguration  
+- Social engineering or physical attacks  
+
+## Safe harbor
+
+We will not pursue legal action against researchers who:
+
+- Make a good-faith effort to avoid privacy violations, data destruction, and service disruption  
+- Report findings promptly and privately  
+- Do not exploit the issue beyond what is needed to demonstrate it  
+
+## Hardening references
+
+Project security-related notes (operational, not a substitute for this policy):
+
+- [docs/ops/security-hardening-phase0.md](docs/ops/security-hardening-phase0.md)  
+- CI: NuGet vulnerability audit, Trivy image scan, CodeQL (see `.github/workflows/security.yml`)
+
+## Preferences for patches
+
+- Prefer minimal, well-tested fixes  
+- Follow [Conventional Commits](docs/ops/commit-conventions.md); security fixes are typically `fix(security): ...`  
+- Versioning follows [SemVer](docs/ops/versioning.md); security fixes without contract breaks are **PATCH** releases  
+
+Thank you for helping keep NotificationHub and its users safe.

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,10 +26,14 @@ ADRs capture **why** a decision was made, alternatives considered, and consequen
 
 Practical runbooks under [`ops/`](ops/):
 
+- [commit-conventions.md](ops/commit-conventions.md) — Conventional Commits (`feat`, `fix`, `ci`, …)
+- [versioning.md](ops/versioning.md) — SemVer 2.0.0, tags `vX.Y.Z`, release workflow, `GET /api/v1/version`
 - [orchestration-otel-aspire.md](ops/orchestration-otel-aspire.md) — Aspire topology, Serilog, Jaeger, health
 - [messaging-reliability.md](ops/messaging-reliability.md) — outbox, ack, DLQ, delayed redelivery
 - [prefetch-tuning.md](ops/prefetch-tuning.md), [latency.md](ops/latency.md)
 - Security hardening notes (`security-hardening-*.md`)
+
+Contributor overview: [CONTRIBUTING.md](../CONTRIBUTING.md).
 
 ## SDK
 

--- a/docs/ops/commit-conventions.md
+++ b/docs/ops/commit-conventions.md
@@ -1,0 +1,106 @@
+# Commit message conventions
+
+NotificationHub uses **Conventional Commits** so history stays readable and [SemVer automation](versioning.md) can classify changes.
+
+## Format
+
+```text
+type(scope): subject
+
+[optional body]
+
+[optional footer]
+```
+
+- **type** — required (see table below)  
+- **scope** — optional area (`api`, `host`, `campaigns`, `ef`, `ci`, `deps`, …)  
+- **subject** — imperative, concise, no trailing period  
+- **Breaking change** — `!` after type/scope and/or footer `BREAKING CHANGE: ...`
+
+### Examples
+
+```text
+feat(auth): add password recovery
+fix(api): fix connection timeout error
+chore(deps): upgrade all dependencies
+docs(api): update developer guide
+test(e2e): add checkout flow test
+refactor(core): simplify cache-lookup logic
+style(ui): fix mobile CSS alignment
+perf(sql): index complex queries for speed
+build(deps): update all packages
+ci(travis): add new node environment
+revert: add login logic
+chore: update code generation script
+```
+
+Breaking:
+
+```text
+feat(api)!: replace payment contract
+
+BREAKING CHANGE: PaymentRequest.amount is now mandatory.
+```
+
+---
+
+## Types
+
+| Type | Meaning | Typical SemVer |
+|------|---------|----------------|
+| **feat** | New user-facing capability | MINOR |
+| **fix** | Bug fix / unintended behavior | PATCH |
+| **perf** | Performance improvement | PATCH |
+| **refactor** | Restructure without behavior change | PATCH |
+| **style** | Formatting only (no logic) | PATCH |
+| **test** | Add or fix tests | PATCH |
+| **docs** | Documentation only | PATCH |
+| **build** | Build system / external build deps | PATCH |
+| **ci** | CI config and scripts | PATCH |
+| **chore** | Maintenance, tooling, non-src noise | PATCH |
+| **revert** | Reverts a previous commit | PATCH (or match original impact) |
+
+Any type with **`!`** or a **`BREAKING CHANGE:`** footer → **MAJOR** (after 1.0; still signal clearly under 0.x).
+
+---
+
+## Scopes (suggested)
+
+| Scope | Area |
+|-------|------|
+| `host` | API host / Program / middleware |
+| `api` | HTTP contracts / endpoints |
+| `campaigns` | Broadcast / batch campaigns |
+| `messaging` | Outbox, RabbitMQ, consumers |
+| `ef` / `db` | EF Core, migrations, schema |
+| `plugins` | Channel plugins |
+| `admin` | Admin UI |
+| `ci` | GitHub Actions |
+| `deps` | Dependency bumps |
+| `security` | Auth, hardening, scanners |
+
+Use a new scope when it helps filtering; omit scope when the change is cross-cutting.
+
+---
+
+## Relation to pull requests
+
+- Prefer **one logical change per commit** on feature branches; squash/rebase is fine if the final messages on `dev` stay conventional.
+- PR title should itself be conventional — it often becomes the merge commit subject.
+- Merges into **`dev`** feed [version.yml](../../.github/workflows/version.yml) for the next tag.
+
+---
+
+## What not to do
+
+- Vague subjects: `update`, `fix stuff`, `WIP`
+- Commit secrets or large generated blobs
+- Mix unrelated features in one commit when it muddies SemVer classification
+- Use `feat` for internal-only refactors (prefer `refactor` / `chore`)
+
+---
+
+## See also
+
+- [versioning.md](versioning.md) — SemVer rules and release workflow  
+- Root [CONTRIBUTING.md](../../CONTRIBUTING.md)  

--- a/docs/ops/versioning.md
+++ b/docs/ops/versioning.md
@@ -1,52 +1,173 @@
 # Versioning (SemVer 2.0.0)
 
-**Source of truth:** `version.json` + `Directory.Build.props` (`VersionPrefix`).
+Unified product version for NotificationHub (application, packages built from this repo, and container tags).
 
-## Scheme
+**API route version** (`/api/v1/...`) is independent of application SemVer. Do not equate `app 2.0.0` with `API v2`.
+
+---
+
+## Source of truth
+
+| Location | Role |
+|----------|------|
+| [`version.json`](../../version.json) | Canonical product version (`MAJOR.MINOR.PATCH`) |
+| [`Directory.Build.props`](../../Directory.Build.props) | `VersionPrefix`, `AssemblyVersion`, `FileVersion`, `InformationalVersion` |
+| Git tag `vMAJOR.MINOR.PATCH` | Immutable release identity |
+| GitHub Release | Notes + publish artifacts |
+
+Avoid diverging versions across `.csproj` files, Docker tags, and packages. CI derives artifacts from the tag / `VersionPrefix`.
+
+---
+
+## SemVer rules
 
 ```text
 MAJOR.MINOR.PATCH
 ```
 
-| Change | Bump |
-|--------|------|
-| Breaking public API / contract | MAJOR |
-| Backward-compatible feature | MINOR |
-| Bug fix / internal / docs | PATCH |
+| Bump | When |
+|------|------|
+| **MAJOR** | Existing consumers can break (public API, contracts, auth, events, required fields, incompatible defaults) |
+| **MINOR** | Backward-compatible functionality (new endpoints, optional fields, features) |
+| **PATCH** | Backward-compatible fixes, security patches without contract change, perf, refactor, docs, tests, internal deps |
 
-Pre-1.0: `0.x.y` — breaking changes may appear between MINOR versions.
+### Pre-1.0 (`0.x.y`)
 
-## Conventional Commits → bump
+Until the first stable public contract:
 
-| Commit prefix | Bump |
-|---------------|------|
-| `feat!:` / `fix!:` / `BREAKING CHANGE:` | MAJOR |
-| `feat:` | MINOR |
-| `fix:` / `perf:` / `refactor:` / `docs:` / `test:` / `chore:` / `ci:` / `build:` / `style:` | PATCH |
+- Start from `0.1.0` for the first meaningful feature set.
+- Breaking changes **may** occur between MINOR versions under `0.x`.
+- Prefer explicit `feat!:` / `BREAKING CHANGE` so automation still bumps MAJOR when you intend a hard break after 1.0.
+
+### Pre-release (optional)
+
+```text
+2.0.0-alpha.1
+2.0.0-beta.1
+2.0.0-rc.1
+2.0.0
+```
+
+Use only when intentionally shipping non-production builds. Tags: `v2.0.0-rc.1`.
+
+### Build metadata
+
+```text
+2.4.1+sha.8f31c2a
+```
+
+Carried in `InformationalVersion`. Does **not** affect SemVer precedence.
+
+---
+
+## Conventional Commits → version bump
+
+Commit messages follow [commit conventions](commit-conventions.md). Automation maps them as:
+
+| Commit signal | Version bump |
+|---------------|--------------|
+| `type!:` or `type(scope)!:` or footer `BREAKING CHANGE:` | **MAJOR** |
+| `feat:` / `feat(scope):` | **MINOR** |
+| `fix`, `perf`, `refactor`, `docs`, `test`, `chore`, `ci`, `build`, `style`, `revert` | **PATCH** |
+
+Do not rely on prefixes alone for public package contracts — still review API/event/DB compatibility before release.
+
+---
 
 ## Workflows
 
-1. **`.github/workflows/version.yml`** — on merge to `dev` (PR closed + merged, or push to `dev`):
-   - reads commits since last `v*` tag
-   - computes next SemVer
-   - updates `version.json` + `Directory.Build.props`
-   - creates annotated tag `vX.Y.Z`
-   - pushes tag (triggers Release)
+### 1. Version bump — `.github/workflows/version.yml`
 
-2. **`.github/workflows/release.yml`** — on tag `v*`:
-   - publishes GitHub Release
-   - builds & pushes container `ghcr.io/...:X.Y.Z`
+**Triggers**
 
-## Runtime
+- Pull request **merged** into `dev`
+- Manual `workflow_dispatch` (optional force: `major` \| `minor` \| `patch` \| `auto`)
+
+**Steps**
+
+1. Read current version from `version.json`.
+2. Inspect commits since last `v*` tag (conventional subjects).
+3. Compute next SemVer.
+4. Update `version.json` and `Directory.Build.props`.
+5. Create annotated tag `vX.Y.Z` (immutable — never move).
+6. Push tag (triggers Release).  
+   - Optional repo secret **`VERSION_BUMP_TOKEN`**: PAT that can push the version commit to protected `dev`. Without it, tag push is still attempted; file updates may need a follow-up PR if branch protection blocks the bot.
+
+### 2. Release — `.github/workflows/release.yml`
+
+**Triggers:** push of tag `v*`
+
+**Produces**
+
+- GitHub Release (generated notes)
+- Container image on GHCR: `ghcr.io/<org>/NotificationHub:X.Y.Z` (and related tags)
+
+Create releases from tags, not by hand-editing an untagged draft only:  
+https://github.com/0x-mhmdnzri/NotificationHub/releases
+
+### 3. Branch protection (`dev`)
+
+Merges into `dev` require green checks (build, format, tests, Trivy, NuGet audit, Docker build). Force-push and branch deletion are disabled.
+
+---
+
+## Runtime identity
 
 ```http
 GET /api/v1/version
 ```
 
-Returns `{ version, commit, product, environment }` (no secrets).
+Example response:
 
-## Rules
+```json
+{
+  "version": "0.1.0",
+  "commit": "aee74c8",
+  "product": "NotificationHub",
+  "environment": "Development"
+}
+```
 
-- Tags are immutable (`v1.2.3` never moved).
-- Wrong release → ship a new PATCH.
-- API path stays `/api/v1` independently of app SemVer.
+No secrets, connection strings, or infrastructure credentials.
+
+---
+
+## Containers
+
+Prefer immutable tags:
+
+```text
+ghcr.io/0x-mhmdnzri/notificationhub:0.1.0
+```
+
+Production should pin to SemVer or digest, not only `latest`.
+
+---
+
+## Database & messages
+
+- **Schema** version = EF migrations / history table — not app SemVer.
+- **Integration events** — additive evolution preferred; breaking event shapes need explicit contract versioning (see [INTEGRATION-EVENT-VERSIONING.md](../INTEGRATION-EVENT-VERSIONING.md)).
+
+---
+
+## Anti-patterns
+
+- PATCH for a breaking API change
+- MAJOR for a trivial internal fix
+- Moving or reusing tag `v1.2.3` on a different commit
+- Different versions in `version.json`, image tag, and assembly with no single source
+- Treating `/api/v1` as the application SemVer
+
+---
+
+## Checklist before a release
+
+1. Previous tag / version identified  
+2. Changes classified (breaking / feature / fix)  
+3. API, package, event, and migration compatibility reviewed  
+4. Tag `vX.Y.Z` created from the intended commit  
+5. Release notes list Added / Fixed / Breaking  
+6. Runtime `GET /api/v1/version` matches the tag  
+
+When uncertain, choose the bump by **consumer compatibility**, not by size of the diff.

--- a/docs/ops/versioning.md
+++ b/docs/ops/versioning.md
@@ -1,0 +1,52 @@
+# Versioning (SemVer 2.0.0)
+
+**Source of truth:** `version.json` + `Directory.Build.props` (`VersionPrefix`).
+
+## Scheme
+
+```text
+MAJOR.MINOR.PATCH
+```
+
+| Change | Bump |
+|--------|------|
+| Breaking public API / contract | MAJOR |
+| Backward-compatible feature | MINOR |
+| Bug fix / internal / docs | PATCH |
+
+Pre-1.0: `0.x.y` — breaking changes may appear between MINOR versions.
+
+## Conventional Commits → bump
+
+| Commit prefix | Bump |
+|---------------|------|
+| `feat!:` / `fix!:` / `BREAKING CHANGE:` | MAJOR |
+| `feat:` | MINOR |
+| `fix:` / `perf:` / `refactor:` / `docs:` / `test:` / `chore:` / `ci:` / `build:` / `style:` | PATCH |
+
+## Workflows
+
+1. **`.github/workflows/version.yml`** — on merge to `dev` (PR closed + merged, or push to `dev`):
+   - reads commits since last `v*` tag
+   - computes next SemVer
+   - updates `version.json` + `Directory.Build.props`
+   - creates annotated tag `vX.Y.Z`
+   - pushes tag (triggers Release)
+
+2. **`.github/workflows/release.yml`** — on tag `v*`:
+   - publishes GitHub Release
+   - builds & pushes container `ghcr.io/...:X.Y.Z`
+
+## Runtime
+
+```http
+GET /api/v1/version
+```
+
+Returns `{ version, commit, product, environment }` (no secrets).
+
+## Rules
+
+- Tags are immutable (`v1.2.3` never moved).
+- Wrong release → ship a new PATCH.
+- API path stays `/api/v1` independently of app SemVer.

--- a/src/Host/NotificationHub.Host/Program.cs
+++ b/src/Host/NotificationHub.Host/Program.cs
@@ -903,4 +903,25 @@ app.MapPost("/api/v1/broadcasts", async (BroadcastRequest body, HttpContext http
 }).WithName("SendBroadcast");
 
 app.MapNotificationHubHealthEndpoints();
+
+// --- Runtime version (SemVer + commit) — no secrets ---
+app.MapGet("/api/v1/version", () =>
+{
+    var asm = typeof(Program).Assembly;
+    var info = asm.GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), false)
+        .OfType<System.Reflection.AssemblyInformationalVersionAttribute>()
+        .FirstOrDefault()?.InformationalVersion
+        ?? asm.GetName().Version?.ToString()
+        ?? "0.0.0";
+    var version = info.Split('+')[0];
+    var commit = info.Contains('+') ? info.Split('+', 2)[1] : (Environment.GetEnvironmentVariable("GITHUB_SHA") ?? "local");
+    return Results.Ok(new
+    {
+        version,
+        commit = commit.Length > 12 ? commit[..12] : commit,
+        product = "NotificationHub",
+        environment = app.Environment.EnvironmentName
+    });
+}).AllowAnonymous().WithName("GetVersion");
+
 app.Run();

--- a/version.json
+++ b/version.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.1.0",
+  "scheme": "semver",
+  "product": "NotificationHub"
+}


### PR DESCRIPTION
## Summary
Adds SemVer 2.0.0 versioning per project skill:
- `version.json` + `Directory.Build.props` VersionPrefix
- `.github/workflows/version.yml` bumps version from conventional commits on merge/push to `dev` and creates immutable `vX.Y.Z` tags
- Existing `release.yml` publishes GitHub Release + GHCR image on tags
- `GET /api/v1/version` runtime identity
- Docs: `docs/ops/versioning.md`

## Test plan
- [ ] CI green on this PR
- [ ] After merge, version workflow runs and tags if commits warrant bump
