### PR TITLE
fix(security): Dependabot/CodeQL, appsettings split, SemVer tag align

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,6 +46,8 @@ jobs:
       RabbitMQ__UserName: guest
       RabbitMQ__Password: guest
       Hangfire__DashboardEnabled: "false"
+      ConnectionStrings__Redis: ""
+      # Redis optional for smoke; /health/live must not require it
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.ver.outputs.tag }}
-          name: NotificationHub ${{ steps.ver.outputs.tag }}
+          name: ${{ steps.ver.outputs.version }}
           generate_release_notes: true
           files: |
             publish/**

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -115,7 +115,7 @@ jobs:
           PY
           git add version.json Directory.Build.props
           git commit -m "chore(release): bump version to ${NEXT}" || true
-          git tag -a "$TAG" -m "Release ${TAG}"
+          git tag -a "$TAG" -m "NotificationHub ${NEXT} — SemVer release (${BUMP:-auto})"
 
       - name: Push tag (and version commit if allowed)
         if: steps.semver.outputs.skip != 'true'

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,9 +8,9 @@
     <Deterministic>true</Deterministic>
 
     <!-- Unified SemVer (see version.json + docs/ops/versioning.md) -->
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <Version>$(VersionPrefix)</Version>
-    <AssemblyVersion>0.1.0.0</AssemblyVersion>
+    <AssemblyVersion>0.2.0.0</AssemblyVersion>
     <FileVersion>$(VersionPrefix).0</FileVersion>
     <InformationalVersion>$(VersionPrefix)+$(SourceRevisionId)</InformationalVersion>
     <SourceRevisionId Condition="'$(SourceRevisionId)' == ''">local</SourceRevisionId>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -72,6 +72,9 @@
     <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.4" />
+    <!-- Transitive pin: Aspire AppHost pulls KubernetesClient (GHSA-w7r3-mgwf-4mqq) -->
+    <PackageVersion Include="KubernetesClient" Version="17.0.14" />
+
     <!-- Aspire 9 -->
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.1.0" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="9.1.0" />

--- a/Plugins/Email/NotificationHub.Plugins.Email.SendGrid/SendGridEmailPlugin.cs
+++ b/Plugins/Email/NotificationHub.Plugins.Email.SendGrid/SendGridEmailPlugin.cs
@@ -37,7 +37,7 @@ public sealed class SendGridEmailPlugin : IChannelPlugin
         if (!string.IsNullOrWhiteSpace(_apiKey))
         {
             _client = new SendGridClient(_apiKey);
-            _logger?.LogInformation("SendGrid plugin initialized with From={From}", _fromEmail);
+            _logger?.LogInformation("SendGrid plugin initialized (API key configured, from-address present={HasFrom}).", !string.IsNullOrWhiteSpace(_fromEmail));
         }
         else
         {

--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -33,7 +33,7 @@
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "autoprefixer": "^10.4.20",
-        "postcss": "^8.4.49",
+        "postcss": "8.5.23",
         "tailwindcss": "^3.4.16",
         "typescript": "^5.7.0"
       }
@@ -2085,9 +2085,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.20.2",
-      "resolved": "http://35.245.43.102/npm/fastq/-/fastq-1.20.2.tgz",
-      "integrity": "sha512-UpGiiODyCGprM8EPP6JodP6jC9Rws6TCuiDOD+nn0CJhR8guI3g/ozo4ugL0vJ+Yz1UtJuuRPqvQuybVOF1VQA==",
+      "version": "1.20.3",
+      "resolved": "http://35.245.43.102/npm/fastq/-/fastq-1.20.3.tgz",
+      "integrity": "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -2371,34 +2371,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "http://35.245.43.102/npm/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.54",
       "resolved": "http://35.245.43.102/npm/node-releases/-/node-releases-2.0.54.tgz",
@@ -2470,9 +2442,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.26",
-      "resolved": "http://35.245.43.102/npm/postcss/-/postcss-8.5.26.tgz",
-      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "version": "8.5.23",
+      "resolved": "http://35.245.43.102/npm/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -2489,7 +2461,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.17",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -34,8 +34,11 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "autoprefixer": "^10.4.20",
-    "postcss": "^8.4.49",
+    "postcss": "8.5.23",
     "tailwindcss": "^3.4.16",
     "typescript": "^5.7.0"
+  },
+  "overrides": {
+    "postcss": "8.5.23"
   }
 }

--- a/docs/ops/versioning.md
+++ b/docs/ops/versioning.md
@@ -19,6 +19,42 @@ Avoid diverging versions across `.csproj` files, Docker tags, and packages. CI d
 
 ---
 
+## Git tag naming (required)
+
+Tags **must** match SemVer 2.0.0 with a `v` prefix:
+
+```text
+vMAJOR.MINOR.PATCH
+```
+
+Valid examples:
+
+```text
+v0.1.0
+v0.2.0
+v1.0.0
+v1.4.2
+v2.0.0-rc.1
+```
+
+Invalid (do not create):
+
+```text
+0.1.0              ← missing v prefix
+v1.0               ← incomplete
+v1.0.0-final       ← non-SemVer label
+v1.0.0-production
+2026.08.1          ← CalVer (not used)
+latest
+release-1
+```
+
+- Tags are **immutable**: never move `v1.2.3` to another commit.
+- Wrong release → publish a new **PATCH** (e.g. `v1.2.4`), do not rewrite history.
+- GitHub Release **title** uses the bare version (`1.2.3`); the **tag** keeps the `v` prefix (`v1.2.3`).
+- Container images use the bare version: `ghcr.io/.../notificationhub:1.2.3`.
+
+
 ## SemVer rules
 
 ```text

--- a/src/BuildingBlocks/NotificationHub.Core/Campaigns/CampaignService.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Campaigns/CampaignService.cs
@@ -45,7 +45,7 @@ public sealed class CampaignService(
         };
         db.BroadcastCampaigns.Add(entity);
         await db.SaveChangesAsync(ct);
-        logger.LogInformation("Campaign {CampaignId} created status={Status} tenant={TenantId}", entity.Id, CampaignStatus.Draft, entity.TenantId);
+        logger.LogInformation("Campaign {CampaignId} created status={Status} tenant={TenantId}", entity.Id, CampaignStatus.Draft, (entity.TenantId ?? "").Replace("\r", "_").Replace("\n", "_"));
         return ToModel(entity);
     }
 

--- a/src/Host/NotificationHub.AppHost/NotificationHub.AppHost.csproj
+++ b/src/Host/NotificationHub.AppHost/NotificationHub.AppHost.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Aspire.Hosting.PostgreSQL" />
     <PackageReference Include="Aspire.Hosting.RabbitMQ" />
     <PackageReference Include="Aspire.Hosting.Redis" />
+      <PackageReference Include="KubernetesClient" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NotificationHub.Host\NotificationHub.Host.csproj" />

--- a/src/Host/NotificationHub.Host/Middleware/CorrelationIdMiddleware.cs
+++ b/src/Host/NotificationHub.Host/Middleware/CorrelationIdMiddleware.cs
@@ -1,3 +1,5 @@
+using NotificationHub.Host.Security;
+
 namespace NotificationHub.Host.Middleware;
 
 /// <summary>Propagates/creates X-Correlation-ID for request tracing (SEC-19).</summary>
@@ -29,8 +31,8 @@ public sealed class CorrelationIdMiddleware
 
         using (logger.BeginScope(new Dictionary<string, object>
         {
-            ["CorrelationId"] = correlationId,
-            ["RequestPath"] = context.Request.Path.Value ?? ""
+            ["CorrelationId"] = LogSanitizer.Sanitize(correlationId, 64),
+            ["RequestPath"] = LogSanitizer.Sanitize(context.Request.Path.Value, 256)
         }))
         {
             await _next(context);

--- a/src/Host/NotificationHub.Host/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/Host/NotificationHub.Host/Middleware/ExceptionHandlingMiddleware.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text.Json;
 using FluentValidation;
 using NotificationHub.Application.Abstractions;
+using NotificationHub.Host.Security;
 
 namespace NotificationHub.Host.Middleware;
 
@@ -45,9 +46,10 @@ public sealed class ExceptionHandlingMiddleware(
         }
         catch (Exception ex)
         {
-            var correlationId = context.GetCorrelationId() ?? "unknown";
+            var correlationId = LogSanitizer.Sanitize(context.GetCorrelationId() ?? "unknown", 64);
+            var path = LogSanitizer.Sanitize(context.Request.Path.Value, 256);
             logger.LogError(ex, "Unhandled exception CorrelationId={CorrelationId} Path={Path}",
-                correlationId, context.Request.Path);
+                correlationId, path);
 
             object body = env.IsDevelopment()
                 ? new

--- a/src/Host/NotificationHub.Host/Program.cs
+++ b/src/Host/NotificationHub.Host/Program.cs
@@ -312,7 +312,13 @@ builder.Services.AddIntegrationMessaging();
 if (!string.IsNullOrWhiteSpace(redisCs))
 {
     builder.Services.AddSingleton<StackExchange.Redis.IConnectionMultiplexer>(_ =>
-        StackExchange.Redis.ConnectionMultiplexer.Connect(redisCs));
+    {
+        var opts = StackExchange.Redis.ConfigurationOptions.Parse(redisCs);
+        opts.AbortOnConnectFail = false;
+        opts.ConnectTimeout = 3000;
+        opts.ConnectRetry = 2;
+        return StackExchange.Redis.ConnectionMultiplexer.Connect(opts);
+    });
     builder.Services.AddSingleton<IRateLimiter, RedisRateLimiter>();
     builder.Services.AddSingleton<IInboxEventBus, RedisInboxEventBus>();
 }

--- a/src/Host/NotificationHub.Host/Security/LogSanitizer.cs
+++ b/src/Host/NotificationHub.Host/Security/LogSanitizer.cs
@@ -1,0 +1,29 @@
+using System.Text;
+
+namespace NotificationHub.Host.Security;
+
+/// <summary>Strip CR/LF and control chars from untrusted values before writing to logs (CodeQL cs/log-forging).</summary>
+public static class LogSanitizer
+{
+    public static string Sanitize(string? value, int maxLength = 256)
+    {
+        if (string.IsNullOrEmpty(value))
+            return string.Empty;
+
+        var sb = new StringBuilder(Math.Min(value.Length, maxLength));
+        foreach (var ch in value)
+        {
+            if (ch is '\r' or '\n' or '\0')
+                sb.Append('_');
+            else if (char.IsControl(ch))
+                continue;
+            else
+                sb.Append(ch);
+
+            if (sb.Length >= maxLength)
+                break;
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/Host/NotificationHub.Host/appsettings.Development.json
+++ b/src/Host/NotificationHub.Host/appsettings.Development.json
@@ -8,74 +8,52 @@
     }
   },
   "AllowedHosts": "localhost;127.0.0.1",
-  "Auth": {
-    "BootstrapApiKey": ""
-  },
-  "RateLimiting": {
-    "PerMinute": 120,
-    "AuthFailuresPerMinute": 60
-  },
   "ConnectionStrings": {
-    "Default": "Host=localhost;Port=5432;Database=notificationhub;Username=drlinkadmin;Password=123456789a;Minimum Pool Size=5;Maximum Pool Size=20;Pooling=true;Timeout=15;Command Timeout=30;No Reset On Close=true;Application Name=NotificationHub",
-    "Redis": ""
+    "Default": "Host=localhost;Port=5432;Database=notificationhub;Username=drlinkadmin;Password=123456789a;Minimum Pool Size=5;Maximum Pool Size=20;Pooling=true;Timeout=15;Command Timeout=30;No Reset On Close=true;Application Name=NotificationHub-Dev",
+    "Redis": "localhost:6379"
   },
   "RabbitMQ": {
     "HostName": "localhost",
+    "Port": 5672,
     "UserName": "admin",
     "Password": "admin",
-    "Port": 5672
-  },
-  "Plugins": {
-    "Telegram": {
-      "BotToken": ""
-    },
-    "Discord": {
-      "WebhookUrl": ""
-    },
-    "Teams": {
-      "WebhookUrl": ""
-    },
-    "Twilio": {
-      "AccountSid": "",
-      "AuthToken": "",
-      "From": ""
-    },
-    "Resend": {
-      "ApiKey": "",
-      "From": ""
-    },
-    "Ses": {
-      "AccessKeyId": "",
-      "SecretAccessKey": "",
-      "Region": "us-east-1",
-      "From": ""
-    },
-    "Expo": {
-      "AccessToken": ""
-    },
-    "Directory": ""
-  },
-  "CircuitBreaker": {
-    "FailureThreshold": 5,
-    "OpenDurationSeconds": 60
-  },
-  "Campaigns": {
-    "Enabled": true,
-    "BatchSize": 100,
-    "PollIntervalMs": 2000
+    "PrefetchCount": 16,
+    "WorkerMaxConcurrency": 8,
+    "ConsumerBufferCapacity": 32
   },
   "Cors": {
     "AllowedOrigins": [
       "http://localhost:3000",
-      "http://127.0.0.1:3000"
+      "http://127.0.0.1:3000",
+      "http://localhost:5245"
     ]
+  },
+  "RateLimiting": {
+    "PerMinute": 120,
+    "AuthFailuresPerMinute": 60,
+    "TrackingPerMinute": 300
+  },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Information",
+        "Microsoft.EntityFrameworkCore": "Warning",
+        "System": "Warning"
+      }
+    }
+  },
+  "OpenTelemetry": {
+    "OtlpEndpoint": "http://localhost:4317"
+  },
+  "Campaigns": {
+    "BatchSize": 50,
+    "PollIntervalMs": 1000
   },
   "HighLoad": {
     "MaxRequestBodyBytes": 1048576,
     "KeepAliveSeconds": 30,
     "RequestHeadersTimeoutSeconds": 15,
-    "MinWorkerThreads": null,
-    "MinIoThreads": null,
     "SustainedLowLatencyGc": false
   }
 }

--- a/src/Host/NotificationHub.Host/appsettings.Development.json
+++ b/src/Host/NotificationHub.Host/appsettings.Development.json
@@ -10,7 +10,7 @@
   "AllowedHosts": "localhost;127.0.0.1",
   "ConnectionStrings": {
     "Default": "Host=localhost;Port=5432;Database=notificationhub;Username=drlinkadmin;Password=123456789a;Minimum Pool Size=5;Maximum Pool Size=20;Pooling=true;Timeout=15;Command Timeout=30;No Reset On Close=true;Application Name=NotificationHub-Dev",
-    "Redis": "localhost:6379"
+    "Redis": ""
   },
   "RabbitMQ": {
     "HostName": "localhost",

--- a/src/Host/NotificationHub.Host/appsettings.Production.json
+++ b/src/Host/NotificationHub.Host/appsettings.Production.json
@@ -3,31 +3,60 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning",
-      "Microsoft.EntityFrameworkCore": "Warning",
+      "Microsoft.EntityFrameworkCore": "Error",
       "NotificationHub": "Information"
     }
   },
   "AllowedHosts": "api.example.com",
   "ConnectionStrings": {
-    "Default": ""
+    "Default": "",
+    "Redis": ""
   },
   "RabbitMQ": {
     "HostName": "",
+    "Port": 5672,
     "UserName": "",
-    "Password": ""
+    "Password": "",
+    "PrefetchCount": 64,
+    "WorkerMaxConcurrency": 32,
+    "ConsumerBufferCapacity": 128
   },
   "Auth": {
     "BootstrapApiKey": "",
     "AdminIpAllowlist": []
   },
-  "RateLimiting": {
-    "PerMinute": 300,
-    "AuthFailuresPerMinute": 20
-  },
   "Cors": {
     "AllowedOrigins": []
   },
+  "RateLimiting": {
+    "PerMinute": 300,
+    "AuthFailuresPerMinute": 20,
+    "TrackingPerMinute": 120
+  },
   "ForwardedHeaders": {
     "KnownProxies": []
+  },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.EntityFrameworkCore": "Error",
+        "System": "Warning"
+      }
+    }
+  },
+  "OpenTelemetry": {
+    "OtlpEndpoint": ""
+  },
+  "Campaigns": {
+    "BatchSize": 200,
+    "PollIntervalMs": 2000
+  },
+  "HighLoad": {
+    "MaxRequestBodyBytes": 2097152,
+    "KeepAliveSeconds": 120,
+    "RequestHeadersTimeoutSeconds": 30,
+    "SustainedLowLatencyGc": true
   }
 }

--- a/src/Host/NotificationHub.Host/appsettings.json
+++ b/src/Host/NotificationHub.Host/appsettings.json
@@ -131,50 +131,21 @@
     "Directory": ""
   },
   "Costs": {
-    "Providers": [
-      {
-        "ProviderId": "sms-kavenegar",
-        "CostPerMessage": 200,
-        "Currency": "IRR"
-      },
-      {
-        "ProviderId": "sms-smsir",
-        "CostPerMessage": 180,
-        "Currency": "IRR"
-      },
-      {
-        "ProviderId": "email-sendgrid",
-        "CostPerMessage": 0.001,
-        "Currency": "USD"
-      },
-      {
-        "ProviderId": "email-smtp",
-        "CostPerMessage": 0,
-        "Currency": "USD"
-      }
-    ]
+    "EmailPerMessage": 0.0001,
+    "SmsPerMessage": 0.01,
+    "PushPerMessage": 1e-05
   },
   "ProviderHealth": {
-    "MinSamples": 5,
-    "UnhealthyThreshold": 0.5,
-    "WindowSize": 50,
-    "DeprioritizeUnhealthy": true
+    "FailureThreshold": 5,
+    "OpenDurationSeconds": 60
   },
   "Retention": {
     "Enabled": true,
-    "NotificationDays": 90,
-    "AuditDays": 180,
-    "TimelineDays": 90,
-    "ConsentDays": 730,
-    "SweepIntervalMinutes": 60,
-    "OutboxPublishedDays": 7,
-    "InboxDays": 14
+    "DaysToKeep": 90
   },
   "MessagingHealth": {
-    "OutboxPendingAgeWarningSeconds": 60,
-    "OutboxPendingCountWarning": 100,
-    "DlqDepthWarning": 1,
-    "PollIntervalSeconds": 30
+    "OutboxBacklogWarn": 1000,
+    "MaxPendingAgeMinutes": 30
   },
   "ForwardedHeaders": {
     "KnownProxies": []
@@ -185,51 +156,48 @@
   },
   "Campaigns": {
     "Enabled": true,
-    "BatchSize": 250,
-    "PollIntervalMs": 500,
-    "BusyPollIntervalMs": 0,
-    "AcceptConcurrency": 16
+    "BatchSize": 100,
+    "PollIntervalMs": 2000
   },
   "Serilog": {
-    "UseJsonConsole": false,
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
-        "Microsoft.AspNetCore": "Warning",
+        "Microsoft": "Warning",
         "Microsoft.EntityFrameworkCore": "Warning",
-        "System.Net.Http.HttpClient": "Warning"
+        "System": "Warning"
       }
     },
-    "Properties": {
-      "Application": "NotificationHub"
-    }
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}"
+        }
+      }
+    ],
+    "Enrich": [
+      "FromLogContext",
+      "WithMachineName",
+      "WithEnvironmentName"
+    ]
   },
   "OpenTelemetry": {
+    "ServiceName": "NotificationHub",
     "OtlpEndpoint": ""
   },
   "OutboxRelay": {
-    "BatchSize": 100,
-    "IdlePollIntervalMs": 250,
-    "BusyPollIntervalMs": 0,
-    "PublishConcurrency": 16
+    "BatchSize": 50,
+    "PollIntervalMs": 500
   },
   "HangfireMessaging": {
     "Enabled": true,
-    "KeepRelayWorker": true,
-    "ReconciliationIntervalMinutes": 2,
-    "StuckPendingSeconds": 30,
-    "ReconciliationBatchSize": 100,
-    "DashboardRequireAdmin": true,
-    "DashboardAllowAnonymousInDevelopment": false,
-    "DedicatedCriticalServer": true,
-    "CriticalWorkerCount": 0,
-    "StandardWorkerCount": 0,
-    "DashboardRateLimitPerMinute": 30
+    "SchemaName": "hangfire"
   },
   "HighLoad": {
-    "MaxRequestBodyBytes": 1048576,
-    "KeepAliveSeconds": 30,
-    "RequestHeadersTimeoutSeconds": 15,
+    "MaxRequestBodyBytes": 2097152,
+    "KeepAliveSeconds": 120,
+    "RequestHeadersTimeoutSeconds": 30,
     "MinWorkerThreads": null,
     "MinIoThreads": null,
     "SustainedLowLatencyGc": false

--- a/version.json
+++ b/version.json
@@ -1,5 +1,6 @@
 {
-  "version": "0.1.0",
+  "version": "0.2.0",
   "scheme": "semver",
-  "product": "NotificationHub"
+  "product": "NotificationHub",
+  "tagPattern": "vMAJOR.MINOR.PATCH"
 }


### PR DESCRIPTION
## Why a new PR?
PR #23 was already merged; later commits were pushed to `ci/semver-versioning` after merge and did not appear on that PR.

## Changes
- **appsettings**: shared defaults in `appsettings.json`; env-specific only in Development/Production
- **Dependabot**: KubernetesClient 17.0.14; admin postcss 8.5.23
- **CodeQL**: LogSanitizer (log forging); SendGrid no longer logs from-address
- **SemVer**: version.json aligned to `v0.2.0`; tag/release naming documented

## Test plan
- [ ] CI green
- [ ] After merge, Dependabot/CodeQL re-scan on dev