### PR TITLE
feat: multi-tenant identity (RBAC/ABAC) + admin UX ops console

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,6 +39,10 @@
     <!-- Messaging / HTTP APIs -->
     <PackageVersion Include="RabbitMQ.Client" Version="7.1.2" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.3.2" />
+    <!-- Identity / OpenIddict -->
+    <PackageVersion Include="OpenIddict.AspNetCore" Version="6.0.0" />
+    <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.4" />
     <!-- Provider SDKs -->
     <PackageVersion Include="SendGrid" Version="9.29.3" />
     <PackageVersion Include="Kavenegar" Version="1.2.5" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,16 +2,10 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-  <!--
-    Central package versions for NotificationHub.
-    Align Microsoft.Extensions.* and EF Core on 9.0.x for net9.0 (avoid mixed 10.x).
-  -->
   <ItemGroup>
-    <!-- Central override: transitive BenchmarkDotNet/older packages pull vulnerable STJ 6.0.0 -->
     <PackageVersion Include="System.Text.Json" Version="9.0.8" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.8" />
 
-    <!-- EF / data -->
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.4" />
@@ -19,7 +13,7 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageVersion Include="Scrutor" Version="4.2.2" />
     <PackageVersion Include="StackExchange.Redis" Version="2.8.31" />
-    <!-- Microsoft.Extensions (net9-aligned) -->
+
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
@@ -28,27 +22,28 @@
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.4" />
-    <!-- CQRS -->
+
     <PackageVersion Include="MediatR" Version="12.4.1" />
     <PackageVersion Include="FluentValidation" Version="11.11.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
-    <!-- Hangfire (durable job execution — not a broker) -->
+
     <PackageVersion Include="Hangfire.Core" Version="1.8.17" />
     <PackageVersion Include="Hangfire.AspNetCore" Version="1.8.17" />
     <PackageVersion Include="Hangfire.PostgreSql" Version="1.20.10" />
-    <!-- Messaging / HTTP APIs -->
+
     <PackageVersion Include="RabbitMQ.Client" Version="7.1.2" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.3.2" />
-    <!-- Identity / OpenIddict -->
+
     <PackageVersion Include="OpenIddict.AspNetCore" Version="6.0.0" />
     <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="6.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.4" />
-    <!-- Provider SDKs -->
+    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="9.0.4" />
+
     <PackageVersion Include="SendGrid" Version="9.29.3" />
     <PackageVersion Include="Kavenegar" Version="1.2.5" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Twilio" Version="7.8.3" />
-    <!-- Test -->
+
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
@@ -56,7 +51,7 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <!-- Observability / Serilog / OTEL -->
+
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
@@ -69,17 +64,15 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.11.0-beta.1" />
-    <!-- Health checks -->
+
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.Rabbitmq" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.4" />
-    <!-- Transitive pin: Aspire AppHost pulls KubernetesClient (GHSA-w7r3-mgwf-4mqq) -->
     <PackageVersion Include="KubernetesClient" Version="17.0.14" />
 
-    <!-- Aspire 9 -->
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.1.0" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="9.1.0" />
     <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="9.1.0" />

--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -1,4 +1,9 @@
 NEXT_PUBLIC_API_BASE_URL=http://localhost:5000
-# Optional. The browser stores runtime session values under localStorage keys:
+NEXT_PUBLIC_IDENTITY_AUTHORITY=http://localhost:5100
+NEXT_PUBLIC_OIDC_CLIENT_ID=admin-ui
+NEXT_PUBLIC_OIDC_REDIRECT_URI=http://localhost:3000/auth/callback
+NEXT_PUBLIC_OIDC_SCOPES=openid profile email notificationhub.admin offline_access
+# Browser session keys (SPA):
 # notificationhub.accessToken
+# notificationhub.refreshToken
 # notificationhub.tenantId

--- a/apps/admin/app/account/sessions/page.tsx
+++ b/apps/admin/app/account/sessions/page.tsx
@@ -31,7 +31,7 @@ export default function SessionsPage() {
           Revoke all
         </Button>
       </div>
-      <SectionCard>
+      <SectionCard title="Active sessions">
         <div className="space-y-3">
           {(sessions.data ?? []).map((s) => (
             <div key={s.id} className="flex flex-col gap-2 rounded-xl border p-4 sm:flex-row sm:items-center">

--- a/apps/admin/app/account/sessions/page.tsx
+++ b/apps/admin/app/account/sessions/page.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { PageHeader } from '@/components/page-header'
+import { SectionCard } from '@/components/section-card'
+import { Button } from '@/components/ui/button'
+import { identityApi } from '@/lib/api/identity'
+
+export default function SessionsPage() {
+  const qc = useQueryClient()
+  const sessions = useQuery({ queryKey: ['auth', 'sessions'], queryFn: () => identityApi.sessions() })
+
+  const revoke = useMutation({
+    mutationFn: (id: string) => identityApi.revokeSession(id),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ['auth', 'sessions'] }),
+  })
+
+  const revokeAll = useMutation({
+    mutationFn: () => identityApi.revokeAllSessions(),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ['auth', 'sessions'] }),
+  })
+
+  return (
+    <div className="p-6 lg:p-8">
+      <PageHeader
+        title="Sessions"
+        description="Active sign-ins across devices. Revoking invalidates refresh tokens."
+      />
+      <div className="mb-4 flex justify-end">
+        <Button variant="ghost" onClick={() => revokeAll.mutate()} disabled={revokeAll.isPending}>
+          Revoke all
+        </Button>
+      </div>
+      <SectionCard>
+        <div className="space-y-3">
+          {(sessions.data ?? []).map((s) => (
+            <div key={s.id} className="flex flex-col gap-2 rounded-xl border p-4 sm:flex-row sm:items-center">
+              <div className="flex-1 text-sm">
+                <div className="font-medium">{s.userAgent || 'Unknown device'}</div>
+                <div className="text-xs text-muted-foreground">
+                  {s.ip || '—'} · last seen {new Date(s.lastSeenAt).toLocaleString()} ·{' '}
+                  {s.isActive ? 'active' : 'revoked'}
+                </div>
+              </div>
+              {s.isActive && (
+                <Button size="sm" variant="ghost" onClick={() => revoke.mutate(s.id)}>
+                  Revoke
+                </Button>
+              )}
+            </div>
+          ))}
+          {sessions.isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+          {!sessions.isLoading && !(sessions.data?.length) && (
+            <p className="text-sm text-muted-foreground">No sessions recorded.</p>
+          )}
+        </div>
+      </SectionCard>
+    </div>
+  )
+}

--- a/apps/admin/app/auth/accept-invite/page.tsx
+++ b/apps/admin/app/auth/accept-invite/page.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { identityApi } from '@/lib/api/identity'
+import { useAuth } from '@/providers/auth-provider'
+import { getAccessToken } from '@/lib/auth/session'
+
+export default function AcceptInvitePage() {
+  const params = useSearchParams()
+  const token = params.get('token') ?? ''
+  const { login, isAuthenticated } = useAuth()
+  const [done, setDone] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [pending, setPending] = useState(false)
+
+  async function accept() {
+    if (!getAccessToken()) {
+      login(`/auth/accept-invite?token=${encodeURIComponent(token)}`)
+      return
+    }
+    setPending(true)
+    setError(null)
+    try {
+      await identityApi.acceptInvite(token)
+      setDone(true)
+    } catch {
+      setError('Invalid or expired invitation')
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <div className="grid min-h-screen place-items-center px-4">
+      <div className="w-full max-w-md rounded-3xl border bg-card p-8 shadow-xl">
+        <h1 className="mb-2 text-lg font-bold">Accept invitation</h1>
+        <p className="mb-6 text-sm text-muted-foreground">
+          {isAuthenticated
+            ? 'Confirm to join the organization.'
+            : 'Sign in first, then accept the invite.'}
+        </p>
+        {done ? (
+          <p className="text-sm text-emerald-600">You joined the organization. <a href="/dashboard" className="underline">Go to dashboard</a></p>
+        ) : (
+          <Button className="w-full" disabled={!token || pending} onClick={() => void accept()}>
+            {isAuthenticated ? 'Accept invite' : 'Sign in to accept'}
+          </Button>
+        )}
+        {error && <p className="mt-3 text-xs text-destructive">{error}</p>}
+      </div>
+    </div>
+  )
+}

--- a/apps/admin/app/auth/accept-invite/page.tsx
+++ b/apps/admin/app/auth/accept-invite/page.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import { useState } from 'react'
+import { Suspense, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { identityApi } from '@/lib/api/identity'
 import { useAuth } from '@/providers/auth-provider'
 import { getAccessToken } from '@/lib/auth/session'
 
-export default function AcceptInvitePage() {
+function AcceptInviteInner() {
   const params = useSearchParams()
   const token = params.get('token') ?? ''
   const { login, isAuthenticated } = useAuth()
@@ -42,7 +42,10 @@ export default function AcceptInvitePage() {
             : 'Sign in first, then accept the invite.'}
         </p>
         {done ? (
-          <p className="text-sm text-emerald-600">You joined the organization. <a href="/dashboard" className="underline">Go to dashboard</a></p>
+          <p className="text-sm text-emerald-600">
+            You joined the organization.{' '}
+            <a href="/dashboard" className="underline">Go to dashboard</a>
+          </p>
         ) : (
           <Button className="w-full" disabled={!token || pending} onClick={() => void accept()}>
             {isAuthenticated ? 'Accept invite' : 'Sign in to accept'}
@@ -51,5 +54,13 @@ export default function AcceptInvitePage() {
         {error && <p className="mt-3 text-xs text-destructive">{error}</p>}
       </div>
     </div>
+  )
+}
+
+export default function AcceptInvitePage() {
+  return (
+    <Suspense fallback={<div className="grid min-h-screen place-items-center text-sm text-muted-foreground">Loading…</div>}>
+      <AcceptInviteInner />
+    </Suspense>
   )
 }

--- a/apps/admin/app/auth/callback/page.tsx
+++ b/apps/admin/app/auth/callback/page.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { handleCallback } from '@/lib/auth/oidc'
+
+export default function AuthCallbackPage() {
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        await handleCallback(window.location.search)
+        const returnTo = sessionStorage.getItem('notificationhub.returnTo') || '/dashboard'
+        sessionStorage.removeItem('notificationhub.returnTo')
+        window.location.replace(returnTo)
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'login_failed')
+      }
+    })()
+  }, [])
+
+  if (error) {
+    return (
+      <div className="grid min-h-screen place-items-center p-6">
+        <div className="rounded-2xl border border-destructive/40 bg-destructive/5 p-6 text-sm">
+          Sign-in failed: {error}
+          <div className="mt-4">
+            <a className="text-primary underline" href="/login">Back to login</a>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid min-h-screen place-items-center text-sm text-muted-foreground">
+      Completing sign-in…
+    </div>
+  )
+}

--- a/apps/admin/app/broadcasts/page.tsx
+++ b/apps/admin/app/broadcasts/page.tsx
@@ -1,3 +1,136 @@
 'use client'
-import {useState} from 'react'; import {PageHeader} from '@/components/page-header'; import {Input} from '@/components/ui/input'; import {Select} from '@/components/ui/select'; import {resourcesApi} from '@/lib/api/resources'; import {useTenant} from '@/providers/tenant-provider'; import {OperationPanel,Field} from '@/components/operation-panel';
-export default function Page(){const {tenantId}=useTenant();const [name,setName]=useState('Product announcement');const [templateKey,setTemplateKey]=useState('');const [channel,setChannel]=useState('push');const [recipients,setRecipients]=useState('');const [segmentKey,setSegmentKey]=useState('');const [locale,setLocale]=useState('fa-IR');const [data,setData]=useState('{}');return <div className="grid-bg min-h-full p-5 md:p-8"><div className="mx-auto max-w-[1000px]"><PageHeader eyebrow="Broadcast" title="Broadcast" description="Dispatch a one-shot broadcast to explicit recipients or a reusable segment."/><OperationPanel title="Send broadcast" description="POST /api/v1/broadcasts" onSubmit={()=>resourcesApi.broadcasts.send({name,templateKey,channel,recipients:recipients.split(/\n|,/).map(x=>x.trim()).filter(Boolean),segmentKey:segmentKey||undefined,locale,tenantId,data:JSON.parse(data)})} label="Send broadcast"><Field label="Name"><Input value={name} onChange={e=>setName(e.target.value)}/></Field><div className="grid gap-3 md:grid-cols-2"><Field label="Template key"><Input value={templateKey} onChange={e=>setTemplateKey(e.target.value)}/></Field><Field label="Channel"><Select value={channel} onChange={e=>setChannel(e.target.value)}><option>push</option><option>email</option><option>sms</option><option>webhook</option></Select></Field></div><div className="grid gap-3 md:grid-cols-2"><Field label="Segment key" hint="optional"><Input value={segmentKey} onChange={e=>setSegmentKey(e.target.value)}/></Field><Field label="Locale"><Input value={locale} onChange={e=>setLocale(e.target.value)}/></Field></div><Field label="Recipients" hint="optional when segment is used"><textarea value={recipients} onChange={e=>setRecipients(e.target.value)} className="min-h-28 w-full rounded-xl border bg-background p-3 font-mono text-xs"/></Field><Field label="Data" hint="JSON"><textarea value={data} onChange={e=>setData(e.target.value)} className="min-h-32 w-full rounded-xl border bg-background p-3 font-mono text-xs"/></Field></OperationPanel></div></div>}
+
+import { useState } from 'react'
+import { PageHeader } from '@/components/page-header'
+import { Input } from '@/components/ui/input'
+import { Select } from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/confirm-dialog'
+import { KeyValueEditor, pairsToRecord, type KeyValuePair } from '@/components/key-value-editor'
+import { ToastHost } from '@/components/toast-host'
+import { resourcesApi } from '@/lib/api/resources'
+import { useTemplates } from '@/hooks/use-templates'
+import { useTenant } from '@/providers/tenant-provider'
+import { formatChannel, friendlyError, templateTitle } from '@/lib/ux/labels'
+
+export default function BroadcastsPage() {
+  const { tenantId } = useTenant()
+  const templates = useTemplates()
+  const [name, setName] = useState('Product announcement')
+  const [templateKey, setTemplateKey] = useState('')
+  const [channel, setChannel] = useState('push')
+  const [recipients, setRecipients] = useState('')
+  const [segmentKey, setSegmentKey] = useState('')
+  const [locale, setLocale] = useState('fa-IR')
+  const [pairs, setPairs] = useState<KeyValuePair[]>([])
+  const [confirm, setConfirm] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [toast, setToast] = useState<{ tone: 'success' | 'error'; title: string; description?: string } | null>(null)
+
+  const list = recipients.split(/\n|,/).map((x) => x.trim()).filter(Boolean)
+  const audienceSize = segmentKey ? 'a saved audience' : `${list.length} recipient${list.length === 1 ? '' : 's'}`
+
+  async function send() {
+    setBusy(true)
+    try {
+      await resourcesApi.broadcasts.send({
+        name,
+        templateKey,
+        channel,
+        recipients: list.length ? list : undefined,
+        segmentKey: segmentKey || undefined,
+        locale,
+        tenantId,
+        data: pairsToRecord(pairs),
+      })
+      setConfirm(false)
+      setToast({ tone: 'success', title: 'Broadcast submitted', description: `Sending via ${formatChannel(channel)}.` })
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not send broadcast', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="grid-bg min-h-full p-5 md:p-8">
+      <ToastHost toast={toast} onClose={() => setToast(null)} />
+      <div className="mx-auto max-w-[900px]">
+        <PageHeader
+          eyebrow="Send"
+          title="Broadcast"
+          description="Send one message to many people at once. Review carefully before sending."
+        />
+        <Card>
+          <CardContent className="space-y-5 p-6">
+            <Field label="Broadcast name"><Input value={name} onChange={(e) => setName(e.target.value)} /></Field>
+            <div className="grid gap-3 md:grid-cols-2">
+              <Field label="Template">
+                <Select value={templateKey} onChange={(e) => setTemplateKey(e.target.value)} className="w-full">
+                  <option value="">Choose template</option>
+                  {templates.data?.map((t) => (
+                    <option key={`${t.key}-${t.channel}`} value={t.key}>{templateTitle(t)} · {formatChannel(t.channel)}</option>
+                  ))}
+                </Select>
+              </Field>
+              <Field label="Channel">
+                <Select value={channel} onChange={(e) => setChannel(e.target.value)} className="w-full">
+                  <option value="push">Push</option>
+                  <option value="email">Email</option>
+                  <option value="sms">SMS</option>
+                </Select>
+              </Field>
+            </div>
+            <Field label="Saved audience code" hint="Optional — use instead of a manual list">
+              <Input value={segmentKey} onChange={(e) => setSegmentKey(e.target.value)} placeholder="e.g. high-value-users" />
+            </Field>
+            <Field label="Recipients" hint="One per line — optional if you use a saved audience">
+              <textarea
+                value={recipients}
+                onChange={(e) => setRecipients(e.target.value)}
+                className="min-h-28 w-full rounded-xl border bg-background p-3 text-sm"
+                placeholder="user-1\nuser-2"
+              />
+            </Field>
+            <Field label="Language"><Input value={locale} onChange={(e) => setLocale(e.target.value)} /></Field>
+            <Field label="Shared personalization">
+              <KeyValueEditor pairs={pairs} onChange={setPairs} />
+            </Field>
+            <Button disabled={!templateKey || (!segmentKey && !list.length)} onClick={() => setConfirm(true)}>
+              Review & send
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+
+      <ConfirmDialog
+        open={confirm}
+        onOpenChange={setConfirm}
+        title="Send this broadcast?"
+        confirmLabel="Yes, send to audience"
+        busy={busy}
+        onConfirm={send}
+        description={
+          <ul className="list-disc space-y-1 pl-4">
+            <li>Name: <strong>{name}</strong></li>
+            <li>Channel: <strong>{formatChannel(channel)}</strong></li>
+            <li>Audience: <strong>{audienceSize}</strong></li>
+          </ul>
+        }
+      />
+    </div>
+  )
+}
+
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-2 text-sm">
+      <span className="flex gap-2 font-medium">
+        {label}
+        {hint && <span className="text-[10px] font-normal text-muted-foreground">{hint}</span>}
+      </span>
+      {children}
+    </label>
+  )
+}

--- a/apps/admin/app/campaigns/page.tsx
+++ b/apps/admin/app/campaigns/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+
 import { useRef, useState } from 'react'
 import { Loader2, Megaphone, Play, Plus, Upload, XCircle } from 'lucide-react'
 import { PageHeader } from '@/components/page-header'
@@ -6,14 +7,305 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Select } from '@/components/ui/select'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
 import { Progress } from '@/components/ui/progress'
 import { Dialog } from '@/components/ui/dialog'
+import { EmptyState } from '@/components/ux/empty-state'
+import { StatusPill } from '@/components/ux/status-pill'
+import { ConfirmDialog } from '@/components/ux/confirm-dialog'
+import {
+  PersonalizationFields,
+  pairsToRecord,
+  type KvPair,
+} from '@/components/ux/personalization-fields'
 import { useTemplates } from '@/hooks/use-templates'
 import { resourcesApi } from '@/lib/api/resources'
 import { useTenant } from '@/providers/tenant-provider'
+import { formatChannel, humanTemplateName, maskId } from '@/lib/ux/labels'
 import type { CreateCampaignRequest } from '@/types/api'
 
-export default function CampaignsPage(){const {tenantId}=useTenant();const templates=useTemplates();const [open,setOpen]=useState(false);const [name,setName]=useState('');const [templateKey,setTemplateKey]=useState('');const [channels,setChannels]=useState<string[]>(['email']);const [scheduled,setScheduled]=useState('');const [data,setData]=useState('{}');const [busy,setBusy]=useState(false);const [campaignId,setCampaignId]=useState('');const [progress,setProgress]=useState<any>();const [recipients,setRecipients]=useState('');const fileRef=useRef<HTMLInputElement>(null);const toggle=(c:string)=>setChannels(x=>x.includes(c)?x.filter(v=>v!==c):[...x,c]);const create=async()=>{if(!name||!templateKey||!channels.length)return;setBusy(true);try{const payload:CreateCampaignRequest={name,templateKey,channels,tenantId,data:JSON.parse(data),scheduledAtUtc:scheduled?new Date(scheduled).toISOString():undefined};const res=await resourcesApi.campaigns.create(payload) as any;setCampaignId(String(res?.id??res?.campaignId??''));setOpen(false)}finally{setBusy(false)}};const addRecipients=async()=>{if(!campaignId||!recipients.trim())return;const addresses=recipients.split(/[\n,;]+/).map(x=>x.trim()).filter(Boolean);await resourcesApi.campaigns.recipients(campaignId,{addresses,channels});setRecipients('')};const importCsv=async(e:React.ChangeEvent<HTMLInputElement>)=>{const file=e.target.files?.[0];if(!file||!campaignId)return;const form=new FormData();form.append('file',file);await resourcesApi.campaigns.importCsv(campaignId,form);if(fileRef.current)fileRef.current.value=''};const inspect=async()=>{if(!campaignId)return;const [p]=await Promise.all([resourcesApi.campaigns.progress(campaignId)]);setProgress(p)};const send=async()=>{if(campaignId)await resourcesApi.campaigns.send(campaignId);await inspect()};const cancel=async()=>{if(campaignId)await resourcesApi.campaigns.cancel(campaignId);await inspect()};return <div className="grid-bg min-h-full p-5 md:p-8"><div className="mx-auto max-w-[1500px]"><PageHeader eyebrow="Broadcast operations" title="Campaigns" description="Create, schedule and operate high-volume notification campaigns." action={<Button onClick={()=>setOpen(true)}><Plus size={16}/>New campaign</Button>}/><div className="grid gap-5 lg:grid-cols-[1fr_360px]"><Card><CardHeader><CardTitle>Campaign workspace</CardTitle></CardHeader><CardContent><EmptyState onCreate={()=>setOpen(true)}/></CardContent></Card><Card><CardHeader><CardTitle>Live operation</CardTitle></CardHeader><CardContent>{campaignId?<div className="space-y-5"><div><div className="text-xs text-muted-foreground">Campaign ID</div><div className="mt-1 break-all font-mono text-xs">{campaignId}</div></div><div className="space-y-3 rounded-xl border bg-muted/20 p-4"><div className="text-sm font-medium">Recipients</div><textarea value={recipients} onChange={e=>setRecipients(e.target.value)} placeholder="user-123\nuser-456\nuser-789" className="min-h-24 w-full rounded-xl border bg-background p-3 font-mono text-xs"/><div className="flex flex-wrap gap-2"><Button variant="outline" onClick={addRecipients} disabled={!recipients.trim()}><Plus size={14}/>Add recipients</Button><Button variant="outline" onClick={()=>fileRef.current?.click()}><Upload size={14}/>Import CSV</Button><input ref={fileRef} type="file" accept=".csv,text/csv" className="hidden" onChange={importCsv}/></div></div><div className="flex gap-2"><Button onClick={send}><Play size={15}/>Send</Button><Button variant="outline" onClick={inspect}>Refresh</Button><Button variant="ghost" className="text-destructive" onClick={cancel}><XCircle size={15}/>Cancel</Button></div>{progress&&<div><div className="mb-2 flex justify-between text-xs"><span>Progress</span><span>{progress?.percentage??progress?.percent??0}%</span></div><Progress value={Number(progress?.percentage??progress?.percent??0)}/><pre className="mt-4 max-h-64 overflow-auto rounded-xl bg-muted p-3 text-[10px]">{JSON.stringify(progress,null,2)}</pre></div>}</div>:<div className="text-sm text-muted-foreground">Create a campaign to control its lifecycle here.</div>}</CardContent></Card></div></div><Dialog open={open} onOpenChange={setOpen} title="Create campaign" description="Build a campaign from an existing template and one or more delivery channels."><div className="space-y-5 p-5"><Field label="Campaign name"><Input value={name} onChange={e=>setName(e.target.value)} placeholder="Weekend payment reminders"/></Field><Field label="Template"><Select value={templateKey} onChange={e=>setTemplateKey(e.target.value)}><option value="">Select a template</option>{templates.data?.map(t=><option key={`${t.key}-${t.channel}-${t.locale}`} value={t.key}>{t.key} · {t.channel} · {t.locale}</option>)}</Select></Field><Field label="Channels"><div className="flex flex-wrap gap-2">{['email','sms','push','webhook'].map(c=><button key={c} onClick={()=>toggle(c)} className={`rounded-xl border px-3 py-2 text-xs transition ${channels.includes(c)?'border-primary bg-primary/10 text-primary':'hover:bg-muted'}`}>{c}</button>)}</div></Field><Field label="Schedule" hint="Optional UTC"><Input type="datetime-local" value={scheduled} onChange={e=>setScheduled(e.target.value)}/></Field><Field label="Data" hint="JSON object"><textarea value={data} onChange={e=>setData(e.target.value)} className="min-h-32 w-full rounded-xl border bg-background p-3 font-mono text-xs"/></Field><div className="flex justify-end border-t pt-4"><Button onClick={create} disabled={busy||!name||!templateKey||!channels.length}>{busy?<Loader2 className="animate-spin" size={15}/>:<Megaphone size={15}/>}Create campaign</Button></div></div></Dialog></div>}
-function Field({label,hint,children}:{label:string;hint?:string;children:React.ReactNode}){return <label className="block space-y-2"><span className="flex gap-2 text-sm font-medium">{label}{hint&&<span className="text-[10px] font-normal text-muted-foreground">{hint}</span>}</span>{children}</label>}
-function EmptyState({onCreate}:{onCreate:()=>void}){return <div className="rounded-2xl border border-dashed p-12 text-center"><div className="mx-auto grid h-12 w-12 place-items-center rounded-2xl bg-primary/10 text-primary"><Megaphone size={22}/></div><h3 className="mt-4 font-semibold">No active campaign loaded</h3><p className="mx-auto mt-2 max-w-md text-sm leading-6 text-muted-foreground">Create a campaign, add recipients through the API or CSV import endpoint, then operate its send and cancellation lifecycle.</p><Button className="mt-5" onClick={onCreate}><Plus size={15}/>Create campaign</Button><div className="mt-6 flex justify-center gap-4 text-xs text-muted-foreground"><span className="flex items-center gap-1"><Upload size={13}/>CSV recipients</span><span>•</span><span>Progress polling</span></div></div>}
+export default function CampaignsPage() {
+  const { tenantId } = useTenant()
+  const templates = useTemplates()
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState('')
+  const [templateKey, setTemplateKey] = useState('')
+  const [channels, setChannels] = useState<string[]>(['email'])
+  const [scheduled, setScheduled] = useState('')
+  const [pairs, setPairs] = useState<KvPair[]>([{ key: '', value: '' }])
+  const [busy, setBusy] = useState(false)
+  const [campaignId, setCampaignId] = useState('')
+  const [campaignName, setCampaignName] = useState('')
+  const [progress, setProgress] = useState<{
+    percentage?: number
+    percent?: number
+    total?: number
+    processed?: number
+    successful?: number
+    failed?: number
+    pending?: number
+    status?: string
+  } | null>(null)
+  const [recipients, setRecipients] = useState('')
+  const [confirmCancel, setConfirmCancel] = useState(false)
+  const fileRef = useRef<HTMLInputElement>(null)
+
+  const toggle = (c: string) =>
+    setChannels((x) => (x.includes(c) ? x.filter((v) => v !== c) : [...x, c]))
+
+  const create = async () => {
+    if (!name || !templateKey || !channels.length) return
+    setBusy(true)
+    try {
+      const payload: CreateCampaignRequest = {
+        name,
+        templateKey,
+        channels,
+        tenantId,
+        data: pairsToRecord(pairs),
+        scheduledAtUtc: scheduled ? new Date(scheduled).toISOString() : undefined,
+      }
+      const res = (await resourcesApi.campaigns.create(payload)) as {
+        id?: string
+        campaignId?: string
+      }
+      setCampaignId(String(res?.id ?? res?.campaignId ?? ''))
+      setCampaignName(name)
+      setOpen(false)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const addRecipients = async () => {
+    if (!campaignId || !recipients.trim()) return
+    const addresses = recipients
+      .split(/[\n,;]+/)
+      .map((x) => x.trim())
+      .filter(Boolean)
+    await resourcesApi.campaigns.recipients(campaignId, { addresses, channels })
+    setRecipients('')
+  }
+
+  const importCsv = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file || !campaignId) return
+    const form = new FormData()
+    form.append('file', file)
+    await resourcesApi.campaigns.importCsv(campaignId, form)
+    if (fileRef.current) fileRef.current.value = ''
+  }
+
+  const inspect = async () => {
+    if (!campaignId) return
+    const p = (await resourcesApi.campaigns.progress(campaignId)) as typeof progress
+    setProgress(p)
+  }
+
+  const send = async () => {
+    if (campaignId) await resourcesApi.campaigns.send(campaignId)
+    await inspect()
+  }
+
+  const cancel = async () => {
+    if (campaignId) await resourcesApi.campaigns.cancel(campaignId)
+    setConfirmCancel(false)
+    await inspect()
+  }
+
+  const pct = Number(progress?.percentage ?? progress?.percent ?? 0)
+
+  return (
+    <div className="grid-bg min-h-full p-5 md:p-8">
+      <div className="mx-auto max-w-[1500px]">
+        <PageHeader
+          eyebrow="Send"
+          title="Campaigns"
+          description="Plan, schedule, and monitor large notification campaigns."
+          action={
+            <Button onClick={() => setOpen(true)}>
+              <Plus size={16} /> New campaign
+            </Button>
+          }
+        />
+
+        <div className="grid gap-5 lg:grid-cols-[1fr_380px]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Campaign workspace</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {!campaignId ? (
+                <EmptyState
+                  icon={Megaphone}
+                  title="No campaign selected"
+                  description="Create a campaign, add your audience, then start sending when you are ready."
+                  actionLabel="Create campaign"
+                  onAction={() => setOpen(true)}
+                />
+              ) : (
+                <div className="space-y-4 text-sm">
+                  <div>
+                    <div className="text-xs text-muted-foreground">Active campaign</div>
+                    <div className="mt-1 text-lg font-semibold">{campaignName || 'Campaign'}</div>
+                    <div className="mt-1 text-xs text-muted-foreground">Ref {maskId(campaignId)}</div>
+                  </div>
+                  {progress && (
+                    <div className="rounded-xl border p-4">
+                      <div className="mb-2 flex items-center justify-between">
+                        <StatusPill status={progress.status ?? (pct >= 100 ? 'Completed' : 'Running')} />
+                        <span className="text-xs text-muted-foreground">{pct}%</span>
+                      </div>
+                      <Progress value={pct} />
+                      <div className="mt-4 grid grid-cols-2 gap-3 text-xs sm:grid-cols-4">
+                        <Metric label="Total" value={progress.total} />
+                        <Metric label="Processed" value={progress.processed} />
+                        <Metric label="Succeeded" value={progress.successful} />
+                        <Metric label="Failed" value={progress.failed} />
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Audience & actions</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {campaignId ? (
+                <div className="space-y-5">
+                  <div className="space-y-3 rounded-xl border bg-muted/20 p-4">
+                    <div className="text-sm font-medium">Add recipients</div>
+                    <textarea
+                      value={recipients}
+                      onChange={(e) => setRecipients(e.target.value)}
+                      placeholder="One recipient per line"
+                      className="min-h-24 w-full rounded-xl border bg-background p-3 text-sm"
+                    />
+                    <div className="flex flex-wrap gap-2">
+                      <Button variant="outline" onClick={addRecipients} disabled={!recipients.trim()}>
+                        <Plus size={14} /> Add list
+                      </Button>
+                      <Button variant="outline" onClick={() => fileRef.current?.click()}>
+                        <Upload size={14} /> Import CSV
+                      </Button>
+                      <input
+                        ref={fileRef}
+                        type="file"
+                        accept=".csv,text/csv"
+                        className="hidden"
+                        onChange={importCsv}
+                      />
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Button onClick={send}>
+                      <Play size={15} /> Start campaign
+                    </Button>
+                    <Button variant="outline" onClick={inspect}>
+                      Refresh progress
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      className="text-destructive"
+                      onClick={() => setConfirmCancel(true)}
+                    >
+                      <XCircle size={15} /> Cancel campaign
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Create a campaign to manage audience and lifecycle here.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      <Dialog
+        open={open}
+        onOpenChange={setOpen}
+        title="New campaign"
+        description="Name the campaign, choose content and channels, then review."
+      >
+        <div className="space-y-5 p-5">
+          <Field label="Campaign name">
+            <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Weekend payment reminders" />
+          </Field>
+          <Field label="Message template">
+            <Select value={templateKey} onChange={(e) => setTemplateKey(e.target.value)}>
+              <option value="">Select a template</option>
+              {templates.data?.map((t) => (
+                <option key={`${t.key}-${t.channel}-${t.locale}`} value={t.key}>
+                  {humanTemplateName(t.key, t.subject)} · {formatChannel(t.channel)}
+                </option>
+              ))}
+            </Select>
+          </Field>
+          <Field label="Channels">
+            <div className="flex flex-wrap gap-2">
+              {['email', 'sms', 'push', 'webhook'].map((c) => (
+                <button
+                  key={c}
+                  type="button"
+                  onClick={() => toggle(c)}
+                  className={`rounded-xl border px-3 py-2 text-xs transition ${
+                    channels.includes(c)
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'hover:bg-muted'
+                  }`}
+                >
+                  {formatChannel(c)}
+                </button>
+              ))}
+            </div>
+          </Field>
+          <Field label="Schedule (optional)">
+            <Input type="datetime-local" value={scheduled} onChange={(e) => setScheduled(e.target.value)} />
+          </Field>
+          <Field label="Personalization">
+            <PersonalizationFields pairs={pairs} onChange={setPairs} />
+          </Field>
+          <div className="flex justify-end border-t pt-4">
+            <Button onClick={create} disabled={busy || !name || !templateKey || !channels.length}>
+              {busy ? <Loader2 className="animate-spin" size={15} /> : <Megaphone size={15} />}
+              Create campaign
+            </Button>
+          </div>
+        </div>
+      </Dialog>
+
+      <ConfirmDialog
+        open={confirmCancel}
+        onOpenChange={setConfirmCancel}
+        title="Cancel this campaign?"
+        description={`Stopping “${campaignName || 'this campaign'}” will prevent remaining messages from being sent. Messages already delivered cannot be recalled.`}
+        confirmLabel="Cancel campaign"
+        destructive
+        onConfirm={cancel}
+      />
+    </div>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-2">
+      <span className="text-sm font-medium">{label}</span>
+      {children}
+    </label>
+  )
+}
+
+function Metric({ label, value }: { label: string; value?: number }) {
+  return (
+    <div>
+      <div className="text-muted-foreground">{label}</div>
+      <div className="text-sm font-semibold">{value ?? '—'}</div>
+    </div>
+  )
+}

--- a/apps/admin/app/campaigns/page.tsx
+++ b/apps/admin/app/campaigns/page.tsx
@@ -7,20 +7,16 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Select } from '@/components/ui/select'
 import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
 import { Progress } from '@/components/ui/progress'
 import { Dialog } from '@/components/ui/dialog'
-import { EmptyState } from '@/components/ux/empty-state'
-import { StatusPill } from '@/components/ux/status-pill'
-import { ConfirmDialog } from '@/components/ux/confirm-dialog'
-import {
-  PersonalizationFields,
-  pairsToRecord,
-  type KvPair,
-} from '@/components/ux/personalization-fields'
+import { ConfirmDialog } from '@/components/confirm-dialog'
+import { KeyValueEditor, pairsToRecord, type KeyValuePair } from '@/components/key-value-editor'
+import { ToastHost } from '@/components/toast-host'
 import { useTemplates } from '@/hooks/use-templates'
 import { resourcesApi } from '@/lib/api/resources'
 import { useTenant } from '@/providers/tenant-provider'
-import { formatChannel, humanTemplateName, maskId } from '@/lib/ux/labels'
+import { formatChannel, formatStatus, friendlyError, statusTone, templateTitle } from '@/lib/ux/labels'
 import type { CreateCampaignRequest } from '@/types/api'
 
 export default function CampaignsPage() {
@@ -31,7 +27,7 @@ export default function CampaignsPage() {
   const [templateKey, setTemplateKey] = useState('')
   const [channels, setChannels] = useState<string[]>(['email'])
   const [scheduled, setScheduled] = useState('')
-  const [pairs, setPairs] = useState<KvPair[]>([{ key: '', value: '' }])
+  const [pairs, setPairs] = useState<KeyValuePair[]>([])
   const [busy, setBusy] = useState(false)
   const [campaignId, setCampaignId] = useState('')
   const [campaignName, setCampaignName] = useState('')
@@ -46,11 +42,12 @@ export default function CampaignsPage() {
     status?: string
   } | null>(null)
   const [recipients, setRecipients] = useState('')
+  const [confirmSend, setConfirmSend] = useState(false)
   const [confirmCancel, setConfirmCancel] = useState(false)
+  const [toast, setToast] = useState<{ tone: 'success' | 'error'; title: string; description?: string } | null>(null)
   const fileRef = useRef<HTMLInputElement>(null)
 
-  const toggle = (c: string) =>
-    setChannels((x) => (x.includes(c) ? x.filter((v) => v !== c) : [...x, c]))
+  const toggle = (c: string) => setChannels((x) => (x.includes(c) ? x.filter((v) => v !== c) : [...x, c]))
 
   const create = async () => {
     if (!name || !templateKey || !channels.length) return
@@ -64,13 +61,14 @@ export default function CampaignsPage() {
         data: pairsToRecord(pairs),
         scheduledAtUtc: scheduled ? new Date(scheduled).toISOString() : undefined,
       }
-      const res = (await resourcesApi.campaigns.create(payload)) as {
-        id?: string
-        campaignId?: string
-      }
-      setCampaignId(String(res?.id ?? res?.campaignId ?? ''))
+      const res = (await resourcesApi.campaigns.create(payload)) as { id?: string; campaignId?: string }
+      const id = String(res?.id ?? res?.campaignId ?? '')
+      setCampaignId(id)
       setCampaignName(name)
       setOpen(false)
+      setToast({ tone: 'success', title: 'Campaign created', description: `“${name}” is ready for recipients.` })
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not create campaign', description: friendlyError(e) })
     } finally {
       setBusy(false)
     }
@@ -78,12 +76,14 @@ export default function CampaignsPage() {
 
   const addRecipients = async () => {
     if (!campaignId || !recipients.trim()) return
-    const addresses = recipients
-      .split(/[\n,;]+/)
-      .map((x) => x.trim())
-      .filter(Boolean)
-    await resourcesApi.campaigns.recipients(campaignId, { addresses, channels })
-    setRecipients('')
+    const addresses = recipients.split(/[\n,;]+/).map((x) => x.trim()).filter(Boolean)
+    try {
+      await resourcesApi.campaigns.recipients(campaignId, { addresses, channels })
+      setRecipients('')
+      setToast({ tone: 'success', title: `${addresses.length} recipients added` })
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not add recipients', description: friendlyError(e) })
+    }
   }
 
   const importCsv = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -91,36 +91,65 @@ export default function CampaignsPage() {
     if (!file || !campaignId) return
     const form = new FormData()
     form.append('file', file)
-    await resourcesApi.campaigns.importCsv(campaignId, form)
+    try {
+      await resourcesApi.campaigns.importCsv(campaignId, form)
+      setToast({ tone: 'success', title: 'Import started', description: file.name })
+    } catch (err) {
+      setToast({ tone: 'error', title: 'Import failed', description: friendlyError(err) })
+    }
     if (fileRef.current) fileRef.current.value = ''
   }
 
   const inspect = async () => {
     if (!campaignId) return
-    const p = (await resourcesApi.campaigns.progress(campaignId)) as typeof progress
-    setProgress(p)
+    try {
+      const p = (await resourcesApi.campaigns.progress(campaignId)) as typeof progress
+      setProgress(p)
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not refresh progress', description: friendlyError(e) })
+    }
   }
 
   const send = async () => {
-    if (campaignId) await resourcesApi.campaigns.send(campaignId)
-    await inspect()
+    if (!campaignId) return
+    setBusy(true)
+    try {
+      await resourcesApi.campaigns.send(campaignId)
+      setConfirmSend(false)
+      setToast({ tone: 'success', title: 'Campaign started' })
+      await inspect()
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not start campaign', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
   }
 
   const cancel = async () => {
-    if (campaignId) await resourcesApi.campaigns.cancel(campaignId)
-    setConfirmCancel(false)
-    await inspect()
+    if (!campaignId) return
+    setBusy(true)
+    try {
+      await resourcesApi.campaigns.cancel(campaignId)
+      setConfirmCancel(false)
+      setToast({ tone: 'success', title: 'Campaign cancelled' })
+      await inspect()
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not cancel', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
   }
 
   const pct = Number(progress?.percentage ?? progress?.percent ?? 0)
 
   return (
     <div className="grid-bg min-h-full p-5 md:p-8">
+      <ToastHost toast={toast} onClose={() => setToast(null)} />
       <div className="mx-auto max-w-[1500px]">
         <PageHeader
           eyebrow="Send"
           title="Campaigns"
-          description="Plan, schedule, and monitor large notification campaigns."
+          description="Reach many people with one message. Build the audience, review, then start."
           action={
             <Button onClick={() => setOpen(true)}>
               <Plus size={16} /> New campaign
@@ -131,39 +160,59 @@ export default function CampaignsPage() {
         <div className="grid gap-5 lg:grid-cols-[1fr_380px]">
           <Card>
             <CardHeader>
-              <CardTitle>Campaign workspace</CardTitle>
+              <CardTitle>{campaignName || 'Campaign workspace'}</CardTitle>
             </CardHeader>
             <CardContent>
               {!campaignId ? (
-                <EmptyState
-                  icon={Megaphone}
-                  title="No campaign selected"
-                  description="Create a campaign, add your audience, then start sending when you are ready."
-                  actionLabel="Create campaign"
-                  onAction={() => setOpen(true)}
-                />
-              ) : (
-                <div className="space-y-4 text-sm">
-                  <div>
-                    <div className="text-xs text-muted-foreground">Active campaign</div>
-                    <div className="mt-1 text-lg font-semibold">{campaignName || 'Campaign'}</div>
-                    <div className="mt-1 text-xs text-muted-foreground">Ref {maskId(campaignId)}</div>
+                <div className="rounded-2xl border border-dashed p-12 text-center">
+                  <div className="mx-auto grid h-12 w-12 place-items-center rounded-2xl bg-primary/10 text-primary">
+                    <Megaphone size={22} />
                   </div>
-                  {progress && (
-                    <div className="rounded-xl border p-4">
-                      <div className="mb-2 flex items-center justify-between">
-                        <StatusPill status={progress.status ?? (pct >= 100 ? 'Completed' : 'Running')} />
-                        <span className="text-xs text-muted-foreground">{pct}%</span>
-                      </div>
-                      <Progress value={pct} />
-                      <div className="mt-4 grid grid-cols-2 gap-3 text-xs sm:grid-cols-4">
-                        <Metric label="Total" value={progress.total} />
-                        <Metric label="Processed" value={progress.processed} />
-                        <Metric label="Succeeded" value={progress.successful} />
-                        <Metric label="Failed" value={progress.failed} />
-                      </div>
+                  <h3 className="mt-4 font-semibold">No campaign selected</h3>
+                  <p className="mx-auto mt-2 max-w-md text-sm leading-6 text-muted-foreground">
+                    Create a campaign, add people by list or spreadsheet, then start sending when you are ready.
+                  </p>
+                  <Button className="mt-5" onClick={() => setOpen(true)}>
+                    <Plus size={15} /> Create campaign
+                  </Button>
+                </div>
+              ) : (
+                <div className="space-y-6">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant={statusTone(progress?.status)}>{formatStatus(progress?.status) || 'Ready'}</Badge>
+                    <span className="text-xs text-muted-foreground">Working campaign</span>
+                  </div>
+
+                  <div className="rounded-xl border bg-muted/20 p-4">
+                    <div className="mb-3 text-sm font-medium">Audience</div>
+                    <textarea
+                      value={recipients}
+                      onChange={(e) => setRecipients(e.target.value)}
+                      placeholder="One recipient per line (user ID, email, or phone)"
+                      className="min-h-28 w-full rounded-xl border bg-background p-3 text-sm"
+                    />
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <Button variant="outline" onClick={() => void addRecipients()} disabled={!recipients.trim()}>
+                        <Plus size={14} /> Add list
+                      </Button>
+                      <Button variant="outline" onClick={() => fileRef.current?.click()}>
+                        <Upload size={14} /> Import spreadsheet
+                      </Button>
+                      <input ref={fileRef} type="file" accept=".csv,text/csv" className="hidden" onChange={(e) => void importCsv(e)} />
                     </div>
-                  )}
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    <Button onClick={() => setConfirmSend(true)}>
+                      <Play size={15} /> Start campaign
+                    </Button>
+                    <Button variant="outline" onClick={() => void inspect()}>
+                      Refresh progress
+                    </Button>
+                    <Button variant="ghost" className="text-destructive" onClick={() => setConfirmCancel(true)}>
+                      <XCircle size={15} /> Cancel campaign
+                    </Button>
+                  </div>
                 </div>
               )}
             </CardContent>
@@ -171,55 +220,30 @@ export default function CampaignsPage() {
 
           <Card>
             <CardHeader>
-              <CardTitle>Audience & actions</CardTitle>
+              <CardTitle>Progress</CardTitle>
             </CardHeader>
             <CardContent>
-              {campaignId ? (
-                <div className="space-y-5">
-                  <div className="space-y-3 rounded-xl border bg-muted/20 p-4">
-                    <div className="text-sm font-medium">Add recipients</div>
-                    <textarea
-                      value={recipients}
-                      onChange={(e) => setRecipients(e.target.value)}
-                      placeholder="One recipient per line"
-                      className="min-h-24 w-full rounded-xl border bg-background p-3 text-sm"
-                    />
-                    <div className="flex flex-wrap gap-2">
-                      <Button variant="outline" onClick={addRecipients} disabled={!recipients.trim()}>
-                        <Plus size={14} /> Add list
-                      </Button>
-                      <Button variant="outline" onClick={() => fileRef.current?.click()}>
-                        <Upload size={14} /> Import CSV
-                      </Button>
-                      <input
-                        ref={fileRef}
-                        type="file"
-                        accept=".csv,text/csv"
-                        className="hidden"
-                        onChange={importCsv}
-                      />
+              {!campaignId && <p className="text-sm text-muted-foreground">Progress appears after you create a campaign.</p>}
+              {campaignId && !progress && (
+                <p className="text-sm text-muted-foreground">Press “Refresh progress” to load the latest numbers.</p>
+              )}
+              {progress && (
+                <div className="space-y-4">
+                  <div>
+                    <div className="mb-2 flex justify-between text-xs">
+                      <span>Completion</span>
+                      <span className="font-medium">{pct}%</span>
                     </div>
+                    <Progress value={pct} />
                   </div>
-                  <div className="flex flex-wrap gap-2">
-                    <Button onClick={send}>
-                      <Play size={15} /> Start campaign
-                    </Button>
-                    <Button variant="outline" onClick={inspect}>
-                      Refresh progress
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      className="text-destructive"
-                      onClick={() => setConfirmCancel(true)}
-                    >
-                      <XCircle size={15} /> Cancel campaign
-                    </Button>
+                  <div className="grid grid-cols-2 gap-3 text-sm">
+                    <Stat label="Total" value={progress.total} />
+                    <Stat label="Processed" value={progress.processed} />
+                    <Stat label="Succeeded" value={progress.successful} good />
+                    <Stat label="Failed" value={progress.failed} bad />
+                    <Stat label="Waiting" value={progress.pending} />
                   </div>
                 </div>
-              ) : (
-                <p className="text-sm text-muted-foreground">
-                  Create a campaign to manage audience and lifecycle here.
-                </p>
               )}
             </CardContent>
           </Card>
@@ -230,7 +254,7 @@ export default function CampaignsPage() {
         open={open}
         onOpenChange={setOpen}
         title="New campaign"
-        description="Name the campaign, choose content and channels, then review."
+        description="Name the campaign, pick a template and channels, then add your audience."
       >
         <div className="space-y-5 p-5">
           <Field label="Campaign name">
@@ -238,10 +262,10 @@ export default function CampaignsPage() {
           </Field>
           <Field label="Message template">
             <Select value={templateKey} onChange={(e) => setTemplateKey(e.target.value)}>
-              <option value="">Select a template</option>
+              <option value="">Choose a template</option>
               {templates.data?.map((t) => (
                 <option key={`${t.key}-${t.channel}-${t.locale}`} value={t.key}>
-                  {humanTemplateName(t.key, t.subject)} · {formatChannel(t.channel)}
+                  {templateTitle(t)} · {formatChannel(t.channel)}
                 </option>
               ))}
             </Select>
@@ -254,9 +278,7 @@ export default function CampaignsPage() {
                   type="button"
                   onClick={() => toggle(c)}
                   className={`rounded-xl border px-3 py-2 text-xs transition ${
-                    channels.includes(c)
-                      ? 'border-primary bg-primary/10 text-primary'
-                      : 'hover:bg-muted'
+                    channels.includes(c) ? 'border-primary bg-primary/10 text-primary' : 'hover:bg-muted'
                   }`}
                 >
                   {formatChannel(c)}
@@ -264,14 +286,14 @@ export default function CampaignsPage() {
               ))}
             </div>
           </Field>
-          <Field label="Schedule (optional)">
+          <Field label="Schedule" hint="Optional — leave empty to start manually">
             <Input type="datetime-local" value={scheduled} onChange={(e) => setScheduled(e.target.value)} />
           </Field>
-          <Field label="Personalization">
-            <PersonalizationFields pairs={pairs} onChange={setPairs} />
+          <Field label="Shared personalization" hint="Optional values applied to all recipients">
+            <KeyValueEditor pairs={pairs} onChange={setPairs} />
           </Field>
           <div className="flex justify-end border-t pt-4">
-            <Button onClick={create} disabled={busy || !name || !templateKey || !channels.length}>
+            <Button onClick={() => void create()} disabled={busy || !name || !templateKey || !channels.length}>
               {busy ? <Loader2 className="animate-spin" size={15} /> : <Megaphone size={15} />}
               Create campaign
             </Button>
@@ -280,32 +302,52 @@ export default function CampaignsPage() {
       </Dialog>
 
       <ConfirmDialog
+        open={confirmSend}
+        onOpenChange={setConfirmSend}
+        title="Start this campaign?"
+        confirmLabel="Yes, start sending"
+        busy={busy}
+        onConfirm={send}
+        description={
+          <p>
+            Messages will begin going out to the audience of <strong>{campaignName || 'this campaign'}</strong>.
+            Make sure recipients and content are correct before continuing.
+          </p>
+        }
+      />
+      <ConfirmDialog
         open={confirmCancel}
         onOpenChange={setConfirmCancel}
         title="Cancel this campaign?"
-        description={`Stopping “${campaignName || 'this campaign'}” will prevent remaining messages from being sent. Messages already delivered cannot be recalled.`}
-        confirmLabel="Cancel campaign"
+        confirmLabel="Yes, cancel it"
         destructive
+        busy={busy}
         onConfirm={cancel}
+        description="Queued messages that have not been sent yet will stop. Messages already delivered cannot be recalled."
       />
     </div>
   )
 }
 
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
   return (
     <label className="block space-y-2">
-      <span className="text-sm font-medium">{label}</span>
+      <span className="flex gap-2 text-sm font-medium">
+        {label}
+        {hint && <span className="text-[10px] font-normal text-muted-foreground">{hint}</span>}
+      </span>
       {children}
     </label>
   )
 }
 
-function Metric({ label, value }: { label: string; value?: number }) {
+function Stat({ label, value, good, bad }: { label: string; value?: number; good?: boolean; bad?: boolean }) {
   return (
-    <div>
-      <div className="text-muted-foreground">{label}</div>
-      <div className="text-sm font-semibold">{value ?? '—'}</div>
+    <div className="rounded-xl border p-3">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className={`mt-1 text-lg font-semibold ${good ? 'text-emerald-600' : bad ? 'text-destructive' : ''}`}>
+        {value ?? '—'}
+      </div>
     </div>
   )
 }

--- a/apps/admin/app/consents/page.tsx
+++ b/apps/admin/app/consents/page.tsx
@@ -1,3 +1,149 @@
 'use client'
-import {useState} from 'react'; import {PageHeader} from '@/components/page-header'; import {Input} from '@/components/ui/input'; import {Select} from '@/components/ui/select'; import {Button} from '@/components/ui/button'; import {resourcesApi} from '@/lib/api/resources'; import {useTenant} from '@/providers/tenant-provider'; import {OperationPanel,Field} from '@/components/operation-panel';
-export default function Page(){const {tenantId}=useTenant();const [subjectId,setSubjectId]=useState('');const [purpose,setPurpose]=useState('marketing');const [channel,setChannel]=useState('email');const [granted,setGranted]=useState(true);const [source,setSource]=useState('admin');const [evidence,setEvidence]=useState('');return <div className="grid-bg min-h-full p-5 md:p-8"><div className="mx-auto max-w-[1100px]"><PageHeader eyebrow="Governance" title="Consents" description="Record consent evidence and evaluate whether a subject can receive a notification for a purpose and channel."/><div className="grid gap-5 lg:grid-cols-2"><OperationPanel title="Record consent" description="POST /api/v1/consents" onSubmit={()=>resourcesApi.consents.record({subjectId,purpose,channel,granted,source,evidence,tenantId,occurredAt:new Date().toISOString()})}><Field label="Subject ID"><Input value={subjectId} onChange={e=>setSubjectId(e.target.value)}/></Field><Field label="Purpose"><Input value={purpose} onChange={e=>setPurpose(e.target.value)}/></Field><Field label="Channel"><Select value={channel} onChange={e=>setChannel(e.target.value)}><option>email</option><option>sms</option><option>push</option><option>webhook</option></Select></Field><Button type="button" variant={granted?'default':'outline'} onClick={()=>setGranted(v=>!v)}>{granted?'Granted':'Revoked'}</Button><Field label="Source"><Input value={source} onChange={e=>setSource(e.target.value)}/></Field><Field label="Evidence"><Input value={evidence} onChange={e=>setEvidence(e.target.value)} placeholder="consent-record-id"/></Field></OperationPanel><OperationPanel title="Evaluate consent" description="POST /api/v1/consents/evaluate" onSubmit={()=>resourcesApi.consents.evaluate({subjectId,purpose,channel,tenantId})} label="Evaluate"><Field label="Subject ID"><Input value={subjectId} onChange={e=>setSubjectId(e.target.value)}/></Field><Field label="Purpose"><Input value={purpose} onChange={e=>setPurpose(e.target.value)}/></Field><Field label="Channel"><Input value={channel} onChange={e=>setChannel(e.target.value)}/></Field></OperationPanel></div></div></div>}
+
+import { useState } from 'react'
+import { PageHeader } from '@/components/page-header'
+import { Input } from '@/components/ui/input'
+import { Select } from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { ToastHost } from '@/components/toast-host'
+import { resourcesApi } from '@/lib/api/resources'
+import { useTenant } from '@/providers/tenant-provider'
+import { formatChannel, friendlyError } from '@/lib/ux/labels'
+
+export default function ConsentsPage() {
+  const { tenantId } = useTenant()
+  const [subjectId, setSubjectId] = useState('')
+  const [purpose, setPurpose] = useState('marketing')
+  const [channel, setChannel] = useState('email')
+  const [granted, setGranted] = useState(true)
+  const [source, setSource] = useState('admin panel')
+  const [evidence, setEvidence] = useState('')
+  const [evalResult, setEvalResult] = useState<'allowed' | 'denied' | null>(null)
+  const [toast, setToast] = useState<{ tone: 'success' | 'error'; title: string; description?: string } | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  async function record() {
+    setBusy(true)
+    try {
+      await resourcesApi.consents.record({
+        subjectId,
+        purpose,
+        channel,
+        granted,
+        source,
+        evidence: evidence || undefined,
+        tenantId,
+        occurredAt: new Date().toISOString(),
+      })
+      setToast({
+        tone: 'success',
+        title: granted ? 'Consent recorded as granted' : 'Consent recorded as withdrawn',
+      })
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not record consent', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function evaluate() {
+    setBusy(true)
+    setEvalResult(null)
+    try {
+      const res = (await resourcesApi.consents.evaluate({ subjectId, purpose, channel, tenantId })) as {
+        allowed?: boolean
+        granted?: boolean
+      } | boolean
+      const ok = typeof res === 'boolean' ? res : Boolean(res?.allowed ?? res?.granted)
+      setEvalResult(ok ? 'allowed' : 'denied')
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not evaluate consent', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="grid-bg min-h-full p-5 md:p-8">
+      <ToastHost toast={toast} onClose={() => setToast(null)} />
+      <div className="mx-auto max-w-[1100px]">
+        <PageHeader
+          eyebrow="Audience"
+          title="Consent"
+          description="Record and check whether someone may receive a type of message."
+        />
+        <div className="grid gap-5 lg:grid-cols-2">
+          <Card>
+            <CardContent className="space-y-4 p-6">
+              <h2 className="font-semibold">Record consent</h2>
+              <Field label="Person"><Input value={subjectId} onChange={(e) => setSubjectId(e.target.value)} placeholder="User or subject ID" /></Field>
+              <Field label="Purpose">
+                <Select value={purpose} onChange={(e) => setPurpose(e.target.value)} className="w-full">
+                  <option value="marketing">Marketing</option>
+                  <option value="transactional">Transactional</option>
+                  <option value="security">Security alerts</option>
+                  <option value="product">Product updates</option>
+                </Select>
+              </Field>
+              <Field label="Channel">
+                <Select value={channel} onChange={(e) => setChannel(e.target.value)} className="w-full">
+                  <option value="email">Email</option>
+                  <option value="sms">SMS</option>
+                  <option value="push">Push</option>
+                  <option value="webhook">Webhook</option>
+                </Select>
+              </Field>
+              <div className="flex gap-2">
+                <Button type="button" variant={granted ? 'default' : 'outline'} onClick={() => setGranted(true)}>Granted</Button>
+                <Button type="button" variant={!granted ? 'default' : 'outline'} onClick={() => setGranted(false)}>Withdrawn</Button>
+              </div>
+              <Field label="Source"><Input value={source} onChange={(e) => setSource(e.target.value)} /></Field>
+              <Field label="Evidence reference" hint="Optional ticket or form ID">
+                <Input value={evidence} onChange={(e) => setEvidence(e.target.value)} />
+              </Field>
+              <Button disabled={busy || !subjectId} onClick={() => void record()}>Save consent record</Button>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent className="space-y-4 p-6">
+              <h2 className="font-semibold">Can we send?</h2>
+              <p className="text-sm text-muted-foreground">
+                Check if this person may receive <strong>{purpose}</strong> messages on <strong>{formatChannel(channel)}</strong>.
+              </p>
+              <Button disabled={busy || !subjectId} variant="outline" onClick={() => void evaluate()}>
+                Check permission
+              </Button>
+              {evalResult === 'allowed' && (
+                <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-4">
+                  <Badge variant="success">Allowed</Badge>
+                  <p className="mt-2 text-sm">Sending is permitted for this purpose and channel.</p>
+                </div>
+              )}
+              {evalResult === 'denied' && (
+                <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-4">
+                  <Badge variant="danger">Not allowed</Badge>
+                  <p className="mt-2 text-sm">Do not send until consent is granted for this purpose.</p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-2 text-sm">
+      <span className="flex gap-2 font-medium">
+        {label}
+        {hint && <span className="text-[10px] font-normal text-muted-foreground">{hint}</span>}
+      </span>
+      {children}
+    </label>
+  )
+}

--- a/apps/admin/app/devices/page.tsx
+++ b/apps/admin/app/devices/page.tsx
@@ -1,3 +1,169 @@
 'use client'
-import {useState} from 'react'; import {PageHeader} from '@/components/page-header'; import {Card,CardContent,CardHeader,CardTitle} from '@/components/ui/card'; import {Input} from '@/components/ui/input'; import {Select} from '@/components/ui/select'; import {Button} from '@/components/ui/button'; import {resourcesApi} from '@/lib/api/resources'; import {useTenant} from '@/providers/tenant-provider'; import {OperationPanel,Field} from '@/components/operation-panel';
-export default function Page(){const {tenantId}=useTenant();const [userId,setUserId]=useState('');const [platform,setPlatform]=useState('ios');const [token,setToken]=useState('');const [locale,setLocale]=useState('fa-IR');const [lookup,setLookup]=useState('');return <div className="grid-bg min-h-full p-5 md:p-8"><div className="mx-auto max-w-[1100px]"><PageHeader eyebrow="Audience" title="Devices" description="Register, inspect and revoke push device tokens."/><div className="grid gap-5 lg:grid-cols-2"><OperationPanel title="Register device" description="POST /api/v1/devices" onSubmit={()=>resourcesApi.devices.register({userId,platform,token,locale,tenantId})}><Field label="User ID"><Input value={userId} onChange={e=>setUserId(e.target.value)}/></Field><Field label="Platform"><Select value={platform} onChange={e=>setPlatform(e.target.value)}><option>ios</option><option>android</option><option>web</option></Select></Field><Field label="Token"><Input value={token} onChange={e=>setToken(e.target.value)} /></Field><Field label="Locale"><Input value={locale} onChange={e=>setLocale(e.target.value)}/></Field></OperationPanel><div className="space-y-5"><OperationPanel title="List devices" description="GET /api/v1/devices/{userId}" onSubmit={()=>resourcesApi.devices.list(lookup,tenantId)} label="Fetch"><Field label="User ID"><Input value={lookup} onChange={e=>setLookup(e.target.value)}/></Field></OperationPanel><OperationPanel title="Unregister device" description="DELETE /api/v1/devices" onSubmit={()=>resourcesApi.devices.unregister({userId:lookup,token,tenantId})} label="Revoke"><Field label="Token"><Input value={token} onChange={e=>setToken(e.target.value)}/></Field></OperationPanel></div></div></div></div>}
+
+import { useState } from 'react'
+import { PageHeader } from '@/components/page-header'
+import { Input } from '@/components/ui/input'
+import { Select } from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { ConfirmDialog } from '@/components/confirm-dialog'
+import { ToastHost } from '@/components/toast-host'
+import { resourcesApi } from '@/lib/api/resources'
+import { useTenant } from '@/providers/tenant-provider'
+import { formatChannel, friendlyError } from '@/lib/ux/labels'
+
+function maskToken(t?: string) {
+  if (!t) return '—'
+  if (t.length <= 8) return '••••'
+  return `${t.slice(0, 4)}…${t.slice(-4)}`
+}
+
+export default function DevicesPage() {
+  const { tenantId } = useTenant()
+  const [userId, setUserId] = useState('')
+  const [platform, setPlatform] = useState('ios')
+  const [token, setToken] = useState('')
+  const [locale, setLocale] = useState('fa-IR')
+  const [lookup, setLookup] = useState('')
+  const [devices, setDevices] = useState<Array<{ platform?: string; token?: string; locale?: string }>>([])
+  const [revokeToken, setRevokeToken] = useState<string | null>(null)
+  const [toast, setToast] = useState<{ tone: 'success' | 'error'; title: string; description?: string } | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  async function register() {
+    setBusy(true)
+    try {
+      await resourcesApi.devices.register({ userId, platform, token, locale, tenantId })
+      setToast({ tone: 'success', title: 'Device registered' })
+      setToken('')
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not register device', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function list() {
+    setBusy(true)
+    try {
+      const res = (await resourcesApi.devices.list(lookup, tenantId)) as Array<Record<string, unknown>>
+      setDevices(
+        (Array.isArray(res) ? res : []).map((d) => ({
+          platform: String(d.platform ?? d.Platform ?? ''),
+          token: String(d.token ?? d.Token ?? ''),
+          locale: String(d.locale ?? d.Locale ?? ''),
+        })),
+      )
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not load devices', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function revoke() {
+    if (!revokeToken || !lookup) return
+    setBusy(true)
+    try {
+      await resourcesApi.devices.unregister({ userId: lookup, token: revokeToken, tenantId })
+      setRevokeToken(null)
+      setToast({ tone: 'success', title: 'Device removed' })
+      await list()
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not remove device', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="grid-bg min-h-full p-5 md:p-8">
+      <ToastHost toast={toast} onClose={() => setToast(null)} />
+      <div className="mx-auto max-w-[1100px]">
+        <PageHeader
+          eyebrow="Audience"
+          title="Devices"
+          description="Manage phones and browsers that can receive push notifications."
+        />
+        <div className="grid gap-5 lg:grid-cols-2">
+          <Card>
+            <CardContent className="space-y-4 p-6">
+              <h2 className="font-semibold">Register a device</h2>
+              <Field label="User">
+                <Input value={userId} onChange={(e) => setUserId(e.target.value)} placeholder="User ID" />
+              </Field>
+              <Field label="Platform">
+                <Select value={platform} onChange={(e) => setPlatform(e.target.value)}>
+                  <option value="ios">iPhone / iPad</option>
+                  <option value="android">Android</option>
+                  <option value="web">Web browser</option>
+                </Select>
+              </Field>
+              <Field label="Device token" hint="Sensitive — stored securely on the server">
+                <Input value={token} onChange={(e) => setToken(e.target.value)} type="password" autoComplete="off" />
+              </Field>
+              <Field label="Language">
+                <Input value={locale} onChange={(e) => setLocale(e.target.value)} />
+              </Field>
+              <Button disabled={busy || !userId || !token} onClick={() => void register()}>
+                Register device
+              </Button>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent className="space-y-4 p-6">
+              <h2 className="font-semibold">Find devices for a user</h2>
+              <Field label="User">
+                <Input value={lookup} onChange={(e) => setLookup(e.target.value)} placeholder="User ID" />
+              </Field>
+              <Button disabled={busy || !lookup} variant="outline" onClick={() => void list()}>
+                Show devices
+              </Button>
+              <div className="space-y-2">
+                {devices.length === 0 && (
+                  <p className="text-sm text-muted-foreground">No devices loaded yet.</p>
+                )}
+                {devices.map((d, i) => (
+                  <div key={i} className="flex items-center justify-between rounded-xl border p-3 text-sm">
+                    <div>
+                      <div className="font-medium">{d.platform === 'ios' ? 'iOS' : d.platform === 'android' ? 'Android' : d.platform || 'Device'}</div>
+                      <div className="text-xs text-muted-foreground">{maskToken(d.token)} · {d.locale || '—'}</div>
+                    </div>
+                    <Button size="sm" variant="ghost" className="text-destructive" onClick={() => setRevokeToken(d.token || null)}>
+                      Remove
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      <ConfirmDialog
+        open={!!revokeToken}
+        onOpenChange={(v) => !v && setRevokeToken(null)}
+        title="Remove this device?"
+        confirmLabel="Yes, remove it"
+        destructive
+        busy={busy}
+        onConfirm={revoke}
+        description="This device will no longer receive push notifications until it is registered again."
+      />
+    </div>
+  )
+}
+
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-2 text-sm">
+      <span className="flex gap-2 font-medium">
+        {label}
+        {hint && <span className="text-[10px] font-normal text-muted-foreground">{hint}</span>}
+      </span>
+      {children}
+    </label>
+  )
+}

--- a/apps/admin/app/engagement/page.tsx
+++ b/apps/admin/app/engagement/page.tsx
@@ -1,3 +1,197 @@
 'use client'
-import {useState} from 'react'; import {BarChart3} from 'lucide-react'; import {PageHeader} from '@/components/page-header'; import {StatCard} from '@/components/stat-card'; import {Card,CardContent,CardHeader,CardTitle} from '@/components/ui/card'; import {Input} from '@/components/ui/input'; import {Select} from '@/components/ui/select'; import {resourcesApi} from '@/lib/api/resources'; import {useTenant} from '@/providers/tenant-provider'; import {OperationPanel,Field} from '@/components/operation-panel';
-export default function Page(){const {tenantId}=useTenant();const [notificationId,setNotificationId]=useState('');const [eventType,setEventType]=useState('opened');const [recipient,setRecipient]=useState('');const [channel,setChannel]=useState('email');const [from,setFrom]=useState('');const [to,setTo]=useState('');return <div className="grid-bg min-h-full p-5 md:p-8"><div className="mx-auto max-w-[1250px]"><PageHeader eyebrow="Analytics" title="Engagement" description="Track opens, clicks and downstream interaction through the engagement contract."/><div className="grid gap-4 md:grid-cols-3"><StatCard label="API surface" value="3 endpoints" change="Live contract" icon={<BarChart3 size={18}/>}/><StatCard label="Event types" value="Custom" change="Provider-aware" icon={<BarChart3 size={18}/>}/><StatCard label="Correlation" value="notificationId" change="Supported" icon={<BarChart3 size={18}/>}/></div><div className="mt-5 grid gap-5 lg:grid-cols-2"><OperationPanel title="Track engagement" description="POST /api/v1/engagement" onSubmit={()=>resourcesApi.engagement.track({notificationId:notificationId||undefined,eventType,recipient,channel,tenantId,occurredAt:new Date().toISOString()})} label="Track event"><Field label="Notification ID"><Input value={notificationId} onChange={e=>setNotificationId(e.target.value)}/></Field><Field label="Event type"><Select value={eventType} onChange={e=>setEventType(e.target.value)}><option>delivered</option><option>opened</option><option>clicked</option><option>failed</option><option>unsubscribed</option></Select></Field><div className="grid grid-cols-2 gap-3"><Field label="Recipient"><Input value={recipient} onChange={e=>setRecipient(e.target.value)}/></Field><Field label="Channel"><Input value={channel} onChange={e=>setChannel(e.target.value)}/></Field></div></OperationPanel><OperationPanel title="Engagement stats" description="GET /api/v1/engagement/stats" onSubmit={()=>resourcesApi.engagement.stats({from:from||undefined,to:to||undefined,tenantId})} label="Query stats"><div className="grid grid-cols-2 gap-3"><Field label="From"><Input type="datetime-local" value={from} onChange={e=>setFrom(e.target.value)}/></Field><Field label="To"><Input type="datetime-local" value={to} onChange={e=>setTo(e.target.value)}/></Field></div></OperationPanel><OperationPanel title="Notification engagement" description="GET /api/v1/notifications/{id}/engagement" onSubmit={()=>resourcesApi.engagement.list(notificationId)} label="Fetch events"><Field label="Notification ID"><Input value={notificationId} onChange={e=>setNotificationId(e.target.value)}/></Field></OperationPanel><Card><CardHeader><CardTitle>Correlation model</CardTitle></CardHeader><CardContent className="text-sm leading-6 text-muted-foreground">Use <code>notificationId</code> for first-party correlation and <code>providerId</code> when provider callbacks need to be reconciled with delivery events.</CardContent></Card></div></div></div>}
+
+import { useState } from 'react'
+import { BarChart3 } from 'lucide-react'
+import { PageHeader } from '@/components/page-header'
+import { StatCard } from '@/components/stat-card'
+import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Select } from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { ToastHost } from '@/components/toast-host'
+import { resourcesApi } from '@/lib/api/resources'
+import { useTenant } from '@/providers/tenant-provider'
+import { formatChannel, formatDateTime, formatStatus, friendlyError } from '@/lib/ux/labels'
+
+const eventLabel: Record<string, string> = {
+  delivered: 'Delivered',
+  opened: 'Opened',
+  clicked: 'Clicked',
+  failed: 'Failed',
+  unsubscribed: 'Unsubscribed',
+  bounced: 'Bounced',
+}
+
+export default function EngagementPage() {
+  const { tenantId } = useTenant()
+  const [notificationId, setNotificationId] = useState('')
+  const [eventType, setEventType] = useState('opened')
+  const [recipient, setRecipient] = useState('')
+  const [channel, setChannel] = useState('email')
+  const [range, setRange] = useState<'7d' | '30d' | 'custom'>('7d')
+  const [from, setFrom] = useState('')
+  const [to, setTo] = useState('')
+  const [stats, setStats] = useState<Record<string, number> | null>(null)
+  const [events, setEvents] = useState<Array<Record<string, unknown>>>([])
+  const [toast, setToast] = useState<{ tone: 'success' | 'error'; title: string; description?: string } | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  function rangeDates() {
+    const now = new Date()
+    if (range === '7d') return { from: new Date(now.getTime() - 7 * 864e5).toISOString(), to: now.toISOString() }
+    if (range === '30d') return { from: new Date(now.getTime() - 30 * 864e5).toISOString(), to: now.toISOString() }
+    return {
+      from: from ? new Date(from).toISOString() : undefined,
+      to: to ? new Date(to).toISOString() : undefined,
+    }
+  }
+
+  async function loadStats() {
+    setBusy(true)
+    try {
+      const { from: f, to: t } = rangeDates()
+      const res = (await resourcesApi.engagement.stats({ from: f, to: t, tenantId })) as Record<string, unknown>
+      const nums: Record<string, number> = {}
+      for (const [k, v] of Object.entries(res || {})) {
+        if (typeof v === 'number') nums[k] = v
+      }
+      setStats(nums)
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not load stats', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function track() {
+    setBusy(true)
+    try {
+      await resourcesApi.engagement.track({
+        notificationId: notificationId || undefined,
+        eventType,
+        recipient,
+        channel,
+        tenantId,
+        occurredAt: new Date().toISOString(),
+      })
+      setToast({ tone: 'success', title: 'Event recorded', description: eventLabel[eventType] || eventType })
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not record event', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function loadEvents() {
+    if (!notificationId) return
+    setBusy(true)
+    try {
+      const res = (await resourcesApi.engagement.list(notificationId)) as Array<Record<string, unknown>>
+      setEvents(Array.isArray(res) ? res : [])
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not load events', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="grid-bg min-h-full p-5 md:p-8">
+      <ToastHost toast={toast} onClose={() => setToast(null)} />
+      <div className="mx-auto max-w-[1200px]">
+        <PageHeader
+          eyebrow="Analytics"
+          title="Engagement"
+          description="See how people interact with your messages."
+        />
+
+        <div className="mb-5 flex flex-wrap items-end gap-3">
+          <div className="flex gap-1 rounded-xl border bg-muted/30 p-1">
+            {([['7d', 'Last 7 days'], ['30d', 'Last 30 days'], ['custom', 'Custom']] as const).map(([k, label]) => (
+              <button
+                key={k}
+                type="button"
+                onClick={() => setRange(k)}
+                className={`rounded-lg px-3 py-2 text-xs font-medium ${range === k ? 'bg-background shadow-sm' : 'text-muted-foreground'}`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          {range === 'custom' && (
+            <>
+              <Input type="datetime-local" value={from} onChange={(e) => setFrom(e.target.value)} />
+              <Input type="datetime-local" value={to} onChange={(e) => setTo(e.target.value)} />
+            </>
+          )}
+          <Button disabled={busy} onClick={() => void loadStats()}>Update overview</Button>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-3">
+          <StatCard label="Opens" value={String(stats?.opened ?? stats?.opens ?? '—')} change="From selected range" icon={<BarChart3 size={18} />} />
+          <StatCard label="Clicks" value={String(stats?.clicked ?? stats?.clicks ?? '—')} change="From selected range" icon={<BarChart3 size={18} />} />
+          <StatCard label="Delivered" value={String(stats?.delivered ?? '—')} change="From selected range" icon={<BarChart3 size={18} />} />
+        </div>
+
+        <div className="mt-5 grid gap-5 lg:grid-cols-2">
+          <Card>
+            <CardContent className="space-y-4 p-6">
+              <h2 className="font-semibold">Record an event</h2>
+              <Field label="Notification reference"><Input value={notificationId} onChange={(e) => setNotificationId(e.target.value)} /></Field>
+              <Field label="What happened">
+                <Select value={eventType} onChange={(e) => setEventType(e.target.value)} className="w-full">
+                  {Object.entries(eventLabel).map(([k, v]) => <option key={k} value={k}>{v}</option>)}
+                </Select>
+              </Field>
+              <div className="grid grid-cols-2 gap-3">
+                <Field label="Recipient"><Input value={recipient} onChange={(e) => setRecipient(e.target.value)} /></Field>
+                <Field label="Channel">
+                  <Select value={channel} onChange={(e) => setChannel(e.target.value)} className="w-full">
+                    <option value="email">Email</option>
+                    <option value="sms">SMS</option>
+                    <option value="push">Push</option>
+                  </Select>
+                </Field>
+              </div>
+              <Button disabled={busy} onClick={() => void track()}>Save event</Button>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent className="space-y-4 p-6">
+              <h2 className="font-semibold">Events for a notification</h2>
+              <Field label="Notification reference"><Input value={notificationId} onChange={(e) => setNotificationId(e.target.value)} /></Field>
+              <Button disabled={busy || !notificationId} variant="outline" onClick={() => void loadEvents()}>
+                Show timeline
+              </Button>
+              <div className="space-y-2">
+                {events.length === 0 && <p className="text-sm text-muted-foreground">No events loaded.</p>}
+                {events.map((ev, i) => (
+                  <div key={i} className="flex items-center justify-between rounded-xl border p-3 text-sm">
+                    <div>
+                      <Badge variant="outline">{eventLabel[String(ev.eventType)] || formatStatus(String(ev.eventType))}</Badge>
+                      <div className="mt-1 text-xs text-muted-foreground">
+                        {formatChannel(String(ev.channel ?? ''))} · {String(ev.recipient ?? '—')}
+                      </div>
+                    </div>
+                    <span className="text-xs text-muted-foreground">{formatDateTime(String(ev.occurredAt ?? ''))}</span>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-2 text-sm">
+      <span className="font-medium">{label}</span>
+      {children}
+    </label>
+  )
+}

--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css'
 import { AppProviders } from '@/providers/app-providers'
 import { Sidebar } from '@/components/sidebar'
 import { Topbar } from '@/components/topbar'
+import { RequireAuth } from '@/components/require-auth'
 
 export const metadata = {
   title: 'NotificationHub',
@@ -13,15 +14,23 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" suppressHydrationWarning>
       <body>
         <AppProviders>
-          <div className="min-h-screen bg-background">
-            <Sidebar />
-            <div className="lg:pl-[270px]">
-              <Topbar />
-              <main className="min-h-[calc(100vh-72px)]">{children}</main>
-            </div>
-          </div>
+          <RequireAuth>
+            <Shell>{children}</Shell>
+          </RequireAuth>
         </AppProviders>
       </body>
     </html>
+  )
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-background">
+      <Sidebar />
+      <div className="lg:pl-[270px]">
+        <Topbar />
+        <main className="min-h-[calc(100vh-72px)]">{children}</main>
+      </div>
+    </div>
   )
 }

--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -1,8 +1,6 @@
 import './globals.css'
 import { AppProviders } from '@/providers/app-providers'
-import { Sidebar } from '@/components/sidebar'
-import { Topbar } from '@/components/topbar'
-import { RequireAuth } from '@/components/require-auth'
+import { AppShell } from '@/components/app-shell'
 
 export const metadata = {
   title: 'NotificationHub',
@@ -14,23 +12,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" suppressHydrationWarning>
       <body>
         <AppProviders>
-          <RequireAuth>
-            <Shell>{children}</Shell>
-          </RequireAuth>
+          <AppShell>{children}</AppShell>
         </AppProviders>
       </body>
     </html>
-  )
-}
-
-function Shell({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="min-h-screen bg-background">
-      <Sidebar />
-      <div className="lg:pl-[270px]">
-        <Topbar />
-        <main className="min-h-[calc(100vh-72px)]">{children}</main>
-      </div>
-    </div>
   )
 }

--- a/apps/admin/app/login/page.tsx
+++ b/apps/admin/app/login/page.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { Layers3 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useAuth } from '@/providers/auth-provider'
+
+export default function LoginPage() {
+  const { login, isAuthenticated } = useAuth()
+
+  if (isAuthenticated) {
+    if (typeof window !== 'undefined') window.location.href = '/dashboard'
+  }
+
+  return (
+    <div className="grid min-h-screen place-items-center bg-background px-4">
+      <div className="w-full max-w-md rounded-3xl border bg-card p-8 shadow-xl">
+        <div className="mb-6 flex items-center gap-3">
+          <div className="grid h-11 w-11 place-items-center rounded-2xl bg-primary text-primary-foreground">
+            <Layers3 size={20} />
+          </div>
+          <div>
+            <div className="text-lg font-bold">NotificationHub</div>
+            <div className="text-xs text-muted-foreground">Admin control plane</div>
+          </div>
+        </div>
+        <p className="mb-6 text-sm leading-6 text-muted-foreground">
+          Sign in with your organization account. Multi-tenant access is enforced server-side.
+        </p>
+        <Button className="w-full" size="lg" onClick={() => login('/dashboard')}>
+          Continue with SSO
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/admin/app/notifications/page.tsx
+++ b/apps/admin/app/notifications/page.tsx
@@ -1,34 +1,31 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { Eye, Loader2, Send, ChevronRight, ChevronLeft } from 'lucide-react'
+import { Check, ChevronLeft, ChevronRight, Eye, Loader2, Send, ShieldCheck } from 'lucide-react'
 import { PageHeader } from '@/components/page-header'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Select } from '@/components/ui/select'
+import { Badge } from '@/components/ui/badge'
 import { SectionCard } from '@/components/section-card'
 import { ToastHost } from '@/components/toast-host'
-import { StatusPill } from '@/components/ux/status-pill'
-import {
-  PersonalizationFields,
-  pairsToRecord,
-  type KvPair,
-} from '@/components/ux/personalization-fields'
+import { ConfirmDialog } from '@/components/confirm-dialog'
+import { KeyValueEditor, pairsToRecord, type KeyValuePair } from '@/components/key-value-editor'
 import { useTemplates } from '@/hooks/use-templates'
 import { ApiError } from '@/lib/api/errors'
 import { notificationsApi } from '@/lib/api/notifications'
-import { formatChannel, friendlyError, humanTemplateName } from '@/lib/ux/labels'
+import {
+  formatChannel,
+  formatStatus,
+  friendlyError,
+  priorityLabel,
+  templateTitle,
+} from '@/lib/ux/labels'
 import type { NotificationPriority, NotificationRequest } from '@/types/api'
 
-const priorityMap: Record<string, NotificationPriority> = {
-  low: 0,
-  normal: 1,
-  high: 2,
-  critical: 3,
-}
-
-const steps = ['Who', 'What', 'Personalize', 'Delivery', 'Review'] as const
+const STEPS = ['Audience', 'Content', 'Personalize', 'Delivery', 'Review'] as const
+const priorityMap: Record<string, NotificationPriority> = { low: 0, normal: 1, high: 2, critical: 3 }
 
 export default function NotificationsPage() {
   const [step, setStep] = useState(0)
@@ -38,29 +35,33 @@ export default function NotificationsPage() {
   const [priority, setPriority] = useState('normal')
   const [locale, setLocale] = useState('fa-IR')
   const [category, setCategory] = useState('transactional')
-  const [pairs, setPairs] = useState<KvPair[]>([
-    { key: 'amount', value: '1,250,000' },
-    { key: 'reference', value: 'PAY-29381' },
-  ])
+  const [pairs, setPairs] = useState<KeyValuePair[]>([{ key: 'amount', value: '' }, { key: 'reference', value: '' }])
   const [scheduledAt, setScheduledAt] = useState('')
   const [timeZoneId, setTimeZoneId] = useState('Asia/Tehran')
   const [allowFallback, setAllowFallback] = useState(true)
-  const [preferredProvider, setPreferredProvider] = useState('')
   const [idempotencyKey, setIdempotencyKey] = useState('')
+  const [preferredProvider, setPreferredProvider] = useState('')
   const [collapseKey, setCollapseKey] = useState('')
   const [showAdvanced, setShowAdvanced] = useState(false)
-  const [busy, setBusy] = useState<'send' | 'wait' | 'preview' | null>(null)
-  const [toast, setToast] = useState<{
-    tone: 'success' | 'error'
-    title: string
-    description?: string
-  } | null>(null)
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [previewText, setPreviewText] = useState<string | null>(null)
+  const [toast, setToast] = useState<{ tone: 'success' | 'error'; title: string; description?: string } | null>(null)
 
   const templatesQuery = useTemplates(channel)
   const selectedTemplate = templatesQuery.data?.find((t) => t.key === templateKey)
 
-  const payload = useMemo((): NotificationRequest | null => {
-    if (!recipient.trim() || !templateKey.trim()) return null
+  const canNext = useMemo(() => {
+    if (step === 0) return recipient.trim().length > 0
+    if (step === 1) return templateKey.trim().length > 0
+    return true
+  }, [step, recipient, templateKey])
+
+  function buildPayload(): NotificationRequest | null {
+    if (!recipient.trim() || !templateKey.trim()) {
+      setToast({ tone: 'error', title: 'Missing information', description: 'Choose a recipient and a template before continuing.' })
+      return null
+    }
     return {
       recipient: recipient.trim(),
       templateKey: templateKey.trim(),
@@ -76,332 +77,317 @@ export default function NotificationsPage() {
       scheduledAt: scheduledAt ? new Date(scheduledAt).toISOString() : undefined,
       timeZoneId: scheduledAt ? timeZoneId : undefined,
     }
-  }, [
-    recipient,
-    templateKey,
-    channel,
-    priority,
-    pairs,
-    idempotencyKey,
-    preferredProvider,
-    allowFallback,
-    category,
-    locale,
-    collapseKey,
-    scheduledAt,
-    timeZoneId,
-  ])
-
-  function canNext() {
-    if (step === 0) return !!recipient.trim()
-    if (step === 1) return !!templateKey.trim()
-    return true
   }
 
-  async function execute(action: 'send' | 'wait' | 'preview') {
-    if (!payload) {
-      setToast({ tone: 'error', title: 'Missing details', description: 'Recipient and content are required.' })
-      return
-    }
-    setBusy(action)
+  async function send() {
+    const payload = buildPayload()
+    if (!payload) return
+    setBusy(true)
     setToast(null)
     try {
-      if (action === 'send') await notificationsApi.send(payload)
-      if (action === 'wait') await notificationsApi.sendSync(payload)
-      if (action === 'preview') await notificationsApi.preview(payload)
+      await notificationsApi.send(payload)
+      setConfirmOpen(false)
       setToast({
         tone: 'success',
-        title:
-          action === 'preview'
-            ? 'Preview ready'
-            : action === 'wait'
-              ? 'Notification delivered'
-              : 'Notification queued',
-        description:
-          action === 'preview'
-            ? 'You can review how the message will look with the current personalization.'
-            : action === 'wait'
-              ? 'The message was processed and a delivery result is available.'
-              : 'The message was accepted and will be delivered shortly.',
+        title: scheduledAt ? 'Notification scheduled' : 'Notification queued',
+        description: `Message for ${recipient.trim()} is on its way via ${formatChannel(channel)}.`,
       })
+      setStep(0)
     } catch (error) {
-      setToast({
-        tone: 'error',
-        title: 'Could not send',
-        description: friendlyError(error instanceof ApiError ? error.message : undefined),
-      })
+      setToast({ tone: 'error', title: 'Could not send', description: friendlyError(error instanceof ApiError ? error : error) })
     } finally {
-      setBusy(null)
+      setBusy(false)
+    }
+  }
+
+  async function preview() {
+    const payload = buildPayload()
+    if (!payload) return
+    setBusy(true)
+    try {
+      const res = await notificationsApi.preview(payload)
+      const text =
+        typeof res === 'string'
+          ? res
+          : (res as { body?: string; subject?: string; content?: string })?.body ||
+            (res as { subject?: string })?.subject ||
+            (res as { content?: string })?.content ||
+            'Preview generated successfully.'
+      setPreviewText(String(text))
+      setToast({ tone: 'success', title: 'Preview ready' })
+    } catch (error) {
+      setToast({ tone: 'error', title: 'Preview failed', description: friendlyError(error) })
+    } finally {
+      setBusy(false)
     }
   }
 
   return (
     <div className="grid-bg min-h-full p-5 md:p-8">
       <ToastHost toast={toast} onClose={() => setToast(null)} />
-      <div className="mx-auto max-w-[960px]">
+      <div className="mx-auto max-w-[1100px]">
         <PageHeader
           eyebrow="Send"
           title="Send a notification"
-          description="Choose who receives the message, pick content, personalize, then review before sending."
+          description="Choose who receives it, what they see, and when it should go out."
         />
 
-        <div className="mb-6 flex flex-wrap gap-2">
-          {steps.map((label, i) => (
+        {/* Step indicator */}
+        <div className="mb-8 flex flex-wrap gap-2">
+          {STEPS.map((label, i) => (
             <button
               key={label}
               type="button"
               onClick={() => i <= step && setStep(i)}
-              className={`rounded-full px-3 py-1.5 text-xs font-medium transition ${
+              className={`flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium transition ${
                 i === step
                   ? 'bg-primary text-primary-foreground'
                   : i < step
-                    ? 'bg-primary/10 text-primary'
+                    ? 'bg-primary/15 text-primary'
                     : 'bg-muted text-muted-foreground'
               }`}
             >
-              {i + 1}. {label}
+              {i < step ? <Check size={12} /> : <span className="opacity-70">{i + 1}</span>}
+              {label}
             </button>
           ))}
         </div>
 
-        <Card>
-          <CardContent className="space-y-6 p-6">
-            {step === 0 && (
-              <div className="space-y-4">
-                <h2 className="text-lg font-semibold">Who should receive this?</h2>
-                <Field label="Recipient">
-                  <Input
-                    value={recipient}
-                    onChange={(e) => setRecipient(e.target.value)}
-                    placeholder="User ID, phone number, or email"
-                  />
-                </Field>
-                <Field label="Channel">
-                  <Select value={channel} onChange={(e) => setChannel(e.target.value)} className="w-full">
-                    <option value="push">Push</option>
-                    <option value="sms">SMS</option>
-                    <option value="email">Email</option>
-                    <option value="webhook">Webhook</option>
-                  </Select>
-                </Field>
-              </div>
-            )}
+        <div className="grid gap-5 lg:grid-cols-[1.4fr_.6fr]">
+          <Card>
+            <CardContent className="space-y-6 p-6">
+              {step === 0 && (
+                <>
+                  <h2 className="text-base font-semibold">Who should receive this?</h2>
+                  <Field label="Recipient" required hint="User ID, phone number, or email">
+                    <Input
+                      value={recipient}
+                      onChange={(e) => setRecipient(e.target.value)}
+                      placeholder="e.g. user-1024 or +98912…"
+                      autoFocus
+                    />
+                  </Field>
+                  <Field label="Channel">
+                    <Select value={channel} onChange={(e) => { setChannel(e.target.value); setTemplateKey('') }} className="w-full">
+                      <option value="push">Push</option>
+                      <option value="sms">SMS</option>
+                      <option value="email">Email</option>
+                      <option value="webhook">Webhook</option>
+                    </Select>
+                  </Field>
+                </>
+              )}
 
-            {step === 1 && (
-              <div className="space-y-4">
-                <h2 className="text-lg font-semibold">What should they receive?</h2>
-                <Field label="Message template">
-                  <Select
-                    value={templateKey}
-                    onChange={(e) => setTemplateKey(e.target.value)}
-                    className="w-full"
-                  >
-                    <option value="">Select a template</option>
-                    {templatesQuery.data?.map((t) => (
-                      <option key={`${t.key}-${t.channel}-${t.locale}`} value={t.key}>
-                        {humanTemplateName(t.key, t.subject)} · {formatChannel(t.channel)} · {t.locale}
-                      </option>
-                    ))}
-                  </Select>
-                </Field>
-                <Field label="Language">
-                  <Input value={locale} onChange={(e) => setLocale(e.target.value)} placeholder="fa-IR" />
-                </Field>
-                {selectedTemplate && (
-                  <div className="rounded-xl border bg-muted/30 p-4 text-sm">
-                    <div className="font-medium">{humanTemplateName(selectedTemplate.key, selectedTemplate.subject)}</div>
-                    <p className="mt-2 text-muted-foreground line-clamp-3">{selectedTemplate.body}</p>
+              {step === 1 && (
+                <>
+                  <h2 className="text-base font-semibold">What should they receive?</h2>
+                  <Field label="Template" required>
+                    <Select value={templateKey} onChange={(e) => setTemplateKey(e.target.value)} className="w-full">
+                      <option value="">Choose a template</option>
+                      {templatesQuery.data?.map((t) => (
+                        <option key={`${t.key}-${t.channel}-${t.locale}`} value={t.key}>
+                          {templateTitle(t)} · {formatChannel(t.channel)} · {t.locale}
+                        </option>
+                      ))}
+                    </Select>
+                  </Field>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <Field label="Language">
+                      <Input value={locale} onChange={(e) => setLocale(e.target.value)} placeholder="fa-IR" />
+                    </Field>
+                    <Field label="Category">
+                      <Select value={category} onChange={(e) => setCategory(e.target.value)} className="w-full">
+                        <option value="transactional">Transactional</option>
+                        <option value="marketing">Marketing</option>
+                        <option value="security">Security</option>
+                        <option value="system">System</option>
+                      </Select>
+                    </Field>
                   </div>
-                )}
-              </div>
-            )}
+                  {selectedTemplate?.subject && (
+                    <div className="rounded-xl border bg-muted/30 p-4 text-sm">
+                      <div className="text-xs text-muted-foreground">Subject preview</div>
+                      <div className="mt-1 font-medium">{selectedTemplate.subject}</div>
+                    </div>
+                  )}
+                </>
+              )}
 
-            {step === 2 && (
-              <div className="space-y-4">
-                <h2 className="text-lg font-semibold">Personalize the message</h2>
-                <PersonalizationFields pairs={pairs} onChange={setPairs} />
-              </div>
-            )}
+              {step === 2 && (
+                <>
+                  <h2 className="text-base font-semibold">Personalization</h2>
+                  <p className="text-sm text-muted-foreground">
+                    Fill in the values your template uses (amounts, names, codes). Leave blank if not needed.
+                  </p>
+                  <KeyValueEditor pairs={pairs} onChange={setPairs} keyPlaceholder="Variable" valuePlaceholder="Value for this send" />
+                </>
+              )}
 
-            {step === 3 && (
-              <div className="space-y-4">
-                <h2 className="text-lg font-semibold">How should it be delivered?</h2>
-                <div className="grid gap-4 md:grid-cols-2">
+              {step === 3 && (
+                <>
+                  <h2 className="text-base font-semibold">When and how to deliver</h2>
                   <Field label="Priority">
                     <Select value={priority} onChange={(e) => setPriority(e.target.value)} className="w-full">
                       <option value="low">Low</option>
                       <option value="normal">Normal</option>
                       <option value="high">High</option>
-                      <option value="critical">Critical</option>
+                      <option value="critical">Urgent</option>
                     </Select>
                   </Field>
-                  <Field label="Category">
-                    <Select value={category} onChange={(e) => setCategory(e.target.value)} className="w-full">
-                      <option value="transactional">Transactional</option>
-                      <option value="marketing">Marketing</option>
-                      <option value="otp">Verification</option>
-                      <option value="alert">Alert</option>
-                    </Select>
-                  </Field>
-                  <Field label="Send later (optional)">
+                  <Field label="Schedule" hint="Leave empty to send immediately">
                     <Input type="datetime-local" value={scheduledAt} onChange={(e) => setScheduledAt(e.target.value)} />
                   </Field>
-                  <Field label="Timezone">
-                    <Input
-                      value={timeZoneId}
-                      onChange={(e) => setTimeZoneId(e.target.value)}
-                      disabled={!scheduledAt}
+                  {scheduledAt && (
+                    <Field label="Time zone">
+                      <Input value={timeZoneId} onChange={(e) => setTimeZoneId(e.target.value)} />
+                    </Field>
+                  )}
+                  <label className="flex cursor-pointer items-start gap-3 rounded-xl border p-4 transition hover:bg-muted/40">
+                    <input
+                      type="checkbox"
+                      checked={allowFallback}
+                      onChange={(e) => setAllowFallback(e.target.checked)}
+                      className="mt-1 h-4 w-4 accent-primary"
                     />
-                  </Field>
-                </div>
-                <label className="flex cursor-pointer items-start gap-3 rounded-xl border p-4">
-                  <input
-                    type="checkbox"
-                    checked={allowFallback}
-                    onChange={(e) => setAllowFallback(e.target.checked)}
-                    className="mt-1 h-4 w-4 accent-primary"
-                  />
-                  <span>
-                    <span className="block text-sm font-medium">Try another provider if the first one fails</span>
-                    <span className="mt-1 block text-xs text-muted-foreground">
-                      Recommended for important messages.
+                    <span>
+                      <span className="block text-sm font-medium">Try another provider if the first fails</span>
+                      <span className="mt-1 block text-xs leading-5 text-muted-foreground">
+                        Recommended for important messages so a single provider outage does not block delivery.
+                      </span>
                     </span>
-                  </span>
-                </label>
-                <button
-                  type="button"
-                  className="text-xs font-medium text-primary"
-                  onClick={() => setShowAdvanced((v) => !v)}
-                >
-                  {showAdvanced ? 'Hide advanced options' : 'Show advanced options'}
-                </button>
-                {showAdvanced && (
-                  <div className="grid gap-4 rounded-xl border border-dashed p-4 md:grid-cols-2">
-                    <Field label="Prevent duplicate sends">
-                      <Input
-                        value={idempotencyKey}
-                        onChange={(e) => setIdempotencyKey(e.target.value)}
-                        placeholder="e.g. payment-29381-success"
-                      />
-                    </Field>
-                    <Field label="Preferred provider">
-                      <Input
-                        value={preferredProvider}
-                        onChange={(e) => setPreferredProvider(e.target.value)}
-                        placeholder="Automatic"
-                      />
-                    </Field>
-                    <Field label="Collapse related messages">
-                      <Input
-                        value={collapseKey}
-                        onChange={(e) => setCollapseKey(e.target.value)}
-                        placeholder="Optional group key"
-                      />
-                    </Field>
-                  </div>
-                )}
-              </div>
-            )}
+                  </label>
+                  <button
+                    type="button"
+                    className="text-xs font-medium text-primary"
+                    onClick={() => setShowAdvanced((v) => !v)}
+                  >
+                    {showAdvanced ? 'Hide advanced options' : 'Show advanced options'}
+                  </button>
+                  {showAdvanced && (
+                    <div className="grid gap-4 rounded-xl border border-dashed p-4 sm:grid-cols-2">
+                      <Field label="Duplicate protection key" hint="Prevents double-send">
+                        <Input value={idempotencyKey} onChange={(e) => setIdempotencyKey(e.target.value)} placeholder="payment-29381" />
+                      </Field>
+                      <Field label="Preferred provider">
+                        <Input value={preferredProvider} onChange={(e) => setPreferredProvider(e.target.value)} placeholder="Automatic" />
+                      </Field>
+                      <Field label="Collapse key" hint="Replace older messages">
+                        <Input value={collapseKey} onChange={(e) => setCollapseKey(e.target.value)} />
+                      </Field>
+                    </div>
+                  )}
+                </>
+              )}
 
-            {step === 4 && (
-              <div className="space-y-4">
-                <h2 className="text-lg font-semibold">Review before sending</h2>
-                <div className="divide-y rounded-xl border">
-                  <ReviewRow label="Recipient" value={recipient || '—'} />
-                  <ReviewRow label="Channel" value={formatChannel(channel)} />
-                  <ReviewRow
-                    label="Content"
-                    value={humanTemplateName(templateKey, selectedTemplate?.subject)}
-                  />
-                  <ReviewRow label="Language" value={locale} />
-                  <ReviewRow label="Priority" value={priority} />
-                  <ReviewRow
-                    label="When"
-                    value={scheduledAt ? `Scheduled · ${scheduledAt} (${timeZoneId})` : 'Send immediately'}
-                  />
-                  <ReviewRow
-                    label="Fallback"
-                    value={allowFallback ? 'Enabled' : 'Disabled'}
-                  />
-                  <ReviewRow
-                    label="Personalization"
-                    value={
-                      Object.entries(pairsToRecord(pairs))
-                        .map(([k, v]) => `${k}: ${v}`)
-                        .join(' · ') || 'None'
-                    }
-                  />
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  This will send a real notification to the recipient on the selected channel.
-                </p>
-              </div>
-            )}
+              {step === 4 && (
+                <>
+                  <h2 className="text-base font-semibold">Review before sending</h2>
+                  <dl className="space-y-3 text-sm">
+                    <ReviewRow label="Recipient" value={recipient} />
+                    <ReviewRow label="Channel" value={formatChannel(channel)} />
+                    <ReviewRow label="Template" value={selectedTemplate ? templateTitle(selectedTemplate) : templateKey} />
+                    <ReviewRow label="Language" value={locale} />
+                    <ReviewRow label="Priority" value={priorityLabel[priority] ?? priority} />
+                    <ReviewRow label="When" value={scheduledAt ? `Scheduled · ${scheduledAt} (${timeZoneId})` : 'Immediately'} />
+                    <ReviewRow label="Fallback providers" value={allowFallback ? 'Yes' : 'No'} />
+                    {Object.keys(pairsToRecord(pairs)).length > 0 && (
+                      <div className="rounded-xl border bg-muted/20 p-3">
+                        <div className="mb-2 text-xs text-muted-foreground">Personalization</div>
+                        <ul className="space-y-1">
+                          {pairs.filter((p) => p.key.trim()).map((p) => (
+                            <li key={p.key} className="flex justify-between gap-4">
+                              <span className="text-muted-foreground">{p.key}</span>
+                              <span className="font-medium">{p.value || '—'}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                  </dl>
+                  {previewText && (
+                    <div className="rounded-xl border bg-background p-4">
+                      <div className="mb-2 text-xs font-medium text-muted-foreground">Content preview</div>
+                      <p className="whitespace-pre-wrap text-sm leading-6">{previewText}</p>
+                    </div>
+                  )}
+                </>
+              )}
 
-            <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-5">
-              <Button
-                variant="ghost"
-                disabled={step === 0 || !!busy}
-                onClick={() => setStep((s) => Math.max(0, s - 1))}
-              >
-                <ChevronLeft size={16} /> Back
-              </Button>
-              <div className="flex flex-wrap gap-2">
-                {step < steps.length - 1 ? (
-                  <Button disabled={!canNext()} onClick={() => setStep((s) => s + 1)}>
-                    Continue <ChevronRight size={16} />
-                  </Button>
-                ) : (
-                  <>
-                    <Button variant="ghost" disabled={!!busy} onClick={() => execute('preview')}>
-                      {busy === 'preview' ? <Loader2 className="animate-spin" size={16} /> : <Eye size={16} />}
+              <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-5">
+                <Button variant="ghost" disabled={step === 0 || busy} onClick={() => setStep((s) => s - 1)}>
+                  <ChevronLeft size={16} /> Back
+                </Button>
+                <div className="flex flex-wrap gap-2">
+                  {step === 4 && (
+                    <Button variant="outline" disabled={busy} onClick={() => void preview()}>
+                      {busy ? <Loader2 className="animate-spin" size={16} /> : <Eye size={16} />}
                       Preview
                     </Button>
-                    <Button variant="outline" disabled={!!busy} onClick={() => execute('wait')}>
-                      {busy === 'wait' ? <Loader2 className="animate-spin" size={16} /> : <Send size={16} />}
-                      Send and wait for result
+                  )}
+                  {step < 4 ? (
+                    <Button disabled={!canNext || busy} onClick={() => setStep((s) => s + 1)}>
+                      Continue <ChevronRight size={16} />
                     </Button>
-                    <Button disabled={!!busy} onClick={() => execute('send')}>
-                      {busy === 'send' ? <Loader2 className="animate-spin" size={16} /> : <Send size={16} />}
-                      Send now
+                  ) : (
+                    <Button disabled={busy} onClick={() => setConfirmOpen(true)}>
+                      <Send size={16} /> {scheduledAt ? 'Schedule' : 'Send'}
                     </Button>
-                  </>
-                )}
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        <div className="mt-6">
-          <SectionCard title="Recent activity" subtitle="Sample deliveries for orientation">
-            <div className="space-y-3">
-              {[
-                ['OTP verification', 'push', 'Delivered', '•••2214'],
-                ['Payment successful', 'sms', 'Delivered', '•••0871'],
-                ['Invoice ready', 'email', 'Queued', 'user@domain.com'],
-              ].map((n) => (
-                <div key={n[0]} className="flex items-center justify-between rounded-xl border p-3 text-sm">
-                  <div>
-                    <div className="font-medium">{n[0]}</div>
-                    <div className="text-xs text-muted-foreground">
-                      {formatChannel(n[1])} · {n[3]}
-                    </div>
-                  </div>
-                  <StatusPill status={n[2]} />
+                  )}
                 </div>
-              ))}
-            </div>
-          </SectionCard>
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="space-y-5">
+            <SectionCard title="Delivery checks">
+              <div className="space-y-3 text-sm">
+                <Row label="Consent" value="Checked on server" good />
+                <Row label="Provider fallback" value={allowFallback ? 'On' : 'Off'} good={allowFallback} />
+                <Row label="Duplicate protection" value={idempotencyKey ? 'On' : 'Off'} good={!!idempotencyKey} />
+              </div>
+            </SectionCard>
+            <Card className="bg-primary text-primary-foreground shadow-lg shadow-primary/20">
+              <CardContent className="p-5">
+                <div className="mb-2 flex items-center gap-2 text-sm font-medium">
+                  <ShieldCheck size={16} /> Safe by design
+                </div>
+                <p className="text-xs leading-5 text-primary-foreground/80">
+                  Tenant isolation, consent, and authorization are enforced by the server. This screen only helps you prepare the message.
+                </p>
+              </CardContent>
+            </Card>
+          </div>
         </div>
       </div>
+
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title={scheduledAt ? 'Schedule this notification?' : 'Send this notification?'}
+        confirmLabel={scheduledAt ? 'Yes, schedule it' : 'Yes, send it'}
+        busy={busy}
+        onConfirm={send}
+        description={
+          <ul className="list-disc space-y-1 pl-4">
+            <li>Recipient: <strong>{recipient}</strong></li>
+            <li>Channel: <strong>{formatChannel(channel)}</strong></li>
+            <li>Template: <strong>{selectedTemplate ? templateTitle(selectedTemplate) : templateKey}</strong></li>
+            <li>Timing: <strong>{scheduledAt || 'Immediately'}</strong></li>
+          </ul>
+        }
+      />
     </div>
   )
 }
 
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
+function Field({ label, required, hint, children }: { label: string; required?: boolean; hint?: string; children: React.ReactNode }) {
   return (
     <label className="block space-y-2 text-sm">
-      <span className="font-medium">{label}</span>
+      <span className="flex items-center gap-2 font-medium">
+        {label}
+        {required && <span className="text-destructive">*</span>}
+        {hint && <span className="text-[10px] font-normal text-muted-foreground">{hint}</span>}
+      </span>
       {children}
     </label>
   )
@@ -409,9 +395,18 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 
 function ReviewRow({ label, value }: { label: string; value: string }) {
   return (
-    <div className="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:justify-between">
-      <span className="text-xs text-muted-foreground">{label}</span>
-      <span className="text-sm font-medium sm:text-right">{value}</span>
+    <div className="flex justify-between gap-4 border-b border-dashed pb-2">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="text-right font-medium">{value || '—'}</dd>
+    </div>
+  )
+}
+
+function Row({ label, value, good }: { label: string; value: string; good?: boolean }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-muted-foreground">{label}</span>
+      <Badge variant={good ? 'success' : 'outline'}>{value}</Badge>
     </div>
   )
 }

--- a/apps/admin/app/notifications/page.tsx
+++ b/apps/admin/app/notifications/page.tsx
@@ -1,64 +1,72 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { Eye, Loader2, Send, ShieldCheck, Sparkles } from 'lucide-react'
+import { Eye, Loader2, Send, ChevronRight, ChevronLeft } from 'lucide-react'
 import { PageHeader } from '@/components/page-header'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Select } from '@/components/ui/select'
-import { Badge } from '@/components/ui/badge'
 import { SectionCard } from '@/components/section-card'
 import { ToastHost } from '@/components/toast-host'
-import { notifications } from '@/lib/mock'
+import { StatusPill } from '@/components/ux/status-pill'
+import {
+  PersonalizationFields,
+  pairsToRecord,
+  type KvPair,
+} from '@/components/ux/personalization-fields'
 import { useTemplates } from '@/hooks/use-templates'
 import { ApiError } from '@/lib/api/errors'
 import { notificationsApi } from '@/lib/api/notifications'
+import { formatChannel, friendlyError, humanTemplateName } from '@/lib/ux/labels'
 import type { NotificationPriority, NotificationRequest } from '@/types/api'
 
-const priorityMap: Record<string, NotificationPriority> = { low: 0, normal: 1, high: 2, critical: 3 }
+const priorityMap: Record<string, NotificationPriority> = {
+  low: 0,
+  normal: 1,
+  high: 2,
+  critical: 3,
+}
 
-export default function Notifications() {
+const steps = ['Who', 'What', 'Personalize', 'Delivery', 'Review'] as const
+
+export default function NotificationsPage() {
+  const [step, setStep] = useState(0)
   const [channel, setChannel] = useState('push')
   const [recipient, setRecipient] = useState('')
   const [templateKey, setTemplateKey] = useState('')
   const [priority, setPriority] = useState('normal')
-  const [idempotencyKey, setIdempotencyKey] = useState('')
-  const [preferredProvider, setPreferredProvider] = useState('')
-  const [category, setCategory] = useState('transactional')
   const [locale, setLocale] = useState('fa-IR')
-  const [collapseKey, setCollapseKey] = useState('')
-  const [dataText, setDataText] = useState('{\n  "amount": "1,250,000",\n  "reference": "PAY-29381"\n}')
-  const [allowFallback, setAllowFallback] = useState(true)
-  const [busy, setBusy] = useState<'send' | 'sync' | 'preview' | null>(null)
+  const [category, setCategory] = useState('transactional')
+  const [pairs, setPairs] = useState<KvPair[]>([
+    { key: 'amount', value: '1,250,000' },
+    { key: 'reference', value: 'PAY-29381' },
+  ])
   const [scheduledAt, setScheduledAt] = useState('')
   const [timeZoneId, setTimeZoneId] = useState('Asia/Tehran')
+  const [allowFallback, setAllowFallback] = useState(true)
+  const [preferredProvider, setPreferredProvider] = useState('')
+  const [idempotencyKey, setIdempotencyKey] = useState('')
+  const [collapseKey, setCollapseKey] = useState('')
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  const [busy, setBusy] = useState<'send' | 'wait' | 'preview' | null>(null)
+  const [toast, setToast] = useState<{
+    tone: 'success' | 'error'
+    title: string
+    description?: string
+  } | null>(null)
+
   const templatesQuery = useTemplates(channel)
-  const [toast, setToast] = useState<{ tone: 'success' | 'error'; title: string; description?: string } | null>(null)
+  const selectedTemplate = templatesQuery.data?.find((t) => t.key === templateKey)
 
-  const parsedData = useMemo(() => {
-    try {
-      return { value: JSON.parse(dataText) as Record<string, unknown>, error: null }
-    } catch {
-      return { value: null, error: 'Template data must be valid JSON.' }
-    }
-  }, [dataText])
-
-  const buildPayload = (): NotificationRequest | null => {
-    if (!recipient.trim() || !templateKey.trim()) {
-      setToast({ tone: 'error', title: 'Missing required fields', description: 'Recipient and template key are required.' })
-      return null
-    }
-    if (parsedData.error) {
-      setToast({ tone: 'error', title: 'Invalid template data', description: parsedData.error })
-      return null
-    }
+  const payload = useMemo((): NotificationRequest | null => {
+    if (!recipient.trim() || !templateKey.trim()) return null
     return {
       recipient: recipient.trim(),
       templateKey: templateKey.trim(),
       channel,
       priority: priorityMap[priority],
-      data: parsedData.value,
+      data: pairsToRecord(pairs),
       idempotencyKey: idempotencyKey.trim() || undefined,
       preferredProvider: preferredProvider.trim() || undefined,
       allowFallback,
@@ -68,25 +76,60 @@ export default function Notifications() {
       scheduledAt: scheduledAt ? new Date(scheduledAt).toISOString() : undefined,
       timeZoneId: scheduledAt ? timeZoneId : undefined,
     }
+  }, [
+    recipient,
+    templateKey,
+    channel,
+    priority,
+    pairs,
+    idempotencyKey,
+    preferredProvider,
+    allowFallback,
+    category,
+    locale,
+    collapseKey,
+    scheduledAt,
+    timeZoneId,
+  ])
+
+  function canNext() {
+    if (step === 0) return !!recipient.trim()
+    if (step === 1) return !!templateKey.trim()
+    return true
   }
 
-  async function execute(action: 'send' | 'sync' | 'preview') {
-    const payload = buildPayload()
-    if (!payload) return
+  async function execute(action: 'send' | 'wait' | 'preview') {
+    if (!payload) {
+      setToast({ tone: 'error', title: 'Missing details', description: 'Recipient and content are required.' })
+      return
+    }
     setBusy(action)
     setToast(null)
     try {
       if (action === 'send') await notificationsApi.send(payload)
-      if (action === 'sync') await notificationsApi.sendSync(payload)
+      if (action === 'wait') await notificationsApi.sendSync(payload)
       if (action === 'preview') await notificationsApi.preview(payload)
       setToast({
         tone: 'success',
-        title: action === 'preview' ? 'Preview generated' : action === 'sync' ? 'Notification sent synchronously' : 'Notification accepted',
-        description: action === 'preview' ? 'The payload was accepted by the template preview endpoint.' : 'The NotificationHub API accepted the request.',
+        title:
+          action === 'preview'
+            ? 'Preview ready'
+            : action === 'wait'
+              ? 'Notification delivered'
+              : 'Notification queued',
+        description:
+          action === 'preview'
+            ? 'You can review how the message will look with the current personalization.'
+            : action === 'wait'
+              ? 'The message was processed and a delivery result is available.'
+              : 'The message was accepted and will be delivered shortly.',
       })
     } catch (error) {
-      const description = error instanceof ApiError ? `${error.message}${error.details?.traceId ? ` · traceId: ${error.details.traceId}` : ''}` : 'Unable to reach the NotificationHub API.'
-      setToast({ tone: 'error', title: 'Request failed', description })
+      setToast({
+        tone: 'error',
+        title: 'Could not send',
+        description: friendlyError(error instanceof ApiError ? error.message : undefined),
+      })
     } finally {
       setBusy(null)
     }
@@ -95,88 +138,259 @@ export default function Notifications() {
   return (
     <div className="grid-bg min-h-full p-5 md:p-8">
       <ToastHost toast={toast} onClose={() => setToast(null)} />
-      <div className="mx-auto max-w-[1500px]">
-        <PageHeader eyebrow="Messaging" title="Send notification" description="Dispatch through the orchestration layer with provider fallback, scheduling and idempotency controls." />
+      <div className="mx-auto max-w-[960px]">
+        <PageHeader
+          eyebrow="Send"
+          title="Send a notification"
+          description="Choose who receives the message, pick content, personalize, then review before sending."
+        />
 
-        <div className="grid gap-5 xl:grid-cols-[1.4fr_.6fr]">
-          <Card className="overflow-hidden">
-            <CardHeader className="border-b bg-muted/20">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <CardTitle>Notification payload</CardTitle>
-                  <p className="mt-1 text-xs text-muted-foreground">Required fields are validated before the request leaves the browser.</p>
-                </div>
-                <Badge variant="outline">POST /notifications</Badge>
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-6 p-6">
-              <div className="grid gap-4 md:grid-cols-2">
-                <Field label="Recipient" required>
-                  <Input value={recipient} onChange={e => setRecipient(e.target.value)} placeholder="user id, phone or email" />
-                </Field>
-                <Field label="Template" required>
-                  <div className="flex gap-2"><Select value={templateKey} onChange={e => setTemplateKey(e.target.value)} className="flex-1"><option value="">Select a template</option>{templatesQuery.data?.map(t => <option key={`${t.key}-${t.channel}-${t.locale}`} value={t.key}>{t.key} · {t.locale}</option>)}</Select><Input value={templateKey} onChange={e => setTemplateKey(e.target.value)} placeholder="or type key" className="hidden md:block md:w-44" /></div>
-                </Field>
-                <Field label="Channel">
-                  <Select value={channel} onChange={e => setChannel(e.target.value)} className="w-full">
-                    <option value="push">Push</option><option value="sms">SMS</option><option value="email">Email</option><option value="webhook">Webhook</option>
-                  </Select>
-                </Field>
-                <Field label="Priority">
-                  <Select value={priority} onChange={e => setPriority(e.target.value)} className="w-full">
-                    <option value="low">Low</option><option value="normal">Normal</option><option value="high">High</option><option value="critical">Critical</option>
-                  </Select>
-                </Field>
-                <Field label="Locale"><Input value={locale} onChange={e => setLocale(e.target.value)} placeholder="fa-IR" /></Field>
-                <Field label="Category"><Input value={category} onChange={e => setCategory(e.target.value)} placeholder="transactional" /></Field>
-              </div>
-
-              <Field label="Template data" hint="JSON object">
-                <textarea value={dataText} onChange={e => setDataText(e.target.value)} className="min-h-40 w-full rounded-xl border bg-background p-3 font-mono text-xs leading-6 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15" spellCheck={false} />
-              </Field>
-
-              <div className="grid gap-4 md:grid-cols-2">
-                <Field label="Schedule" hint="Optional"><Input type="datetime-local" value={scheduledAt} onChange={e => setScheduledAt(e.target.value)} /></Field>
-                <Field label="Time zone"><Input value={timeZoneId} onChange={e => setTimeZoneId(e.target.value)} disabled={!scheduledAt} /></Field>
-                <Field label="Idempotency key" hint="Recommended"><Input value={idempotencyKey} onChange={e => setIdempotencyKey(e.target.value)} placeholder="payment:29381:success" /></Field>
-                <Field label="Preferred provider"><Input value={preferredProvider} onChange={e => setPreferredProvider(e.target.value)} placeholder="auto" /></Field>
-                <Field label="Collapse key"><Input value={collapseKey} onChange={e => setCollapseKey(e.target.value)} placeholder="payment-status" /></Field>
-              </div>
-
-              <label className="flex cursor-pointer items-start gap-3 rounded-xl border p-4 transition hover:bg-muted/40">
-                <input type="checkbox" checked={allowFallback} onChange={e => setAllowFallback(e.target.checked)} className="mt-1 h-4 w-4 accent-primary" />
-                <span><span className="block text-sm font-medium">Allow provider fallback</span><span className="mt-1 block text-xs leading-5 text-muted-foreground">Let the orchestration layer move to another provider when the preferred provider cannot deliver.</span></span>
-              </label>
-
-              <div className="flex flex-wrap gap-2 border-t pt-5">
-                <Button disabled={!!busy} onClick={() => execute('send')}>{busy === 'send' ? <Loader2 className="animate-spin" size={16} /> : <Send size={16} />}Send now</Button>
-                <Button variant="outline" disabled={!!busy} onClick={() => execute('sync')}>{busy === 'sync' ? <Loader2 className="animate-spin" size={16} /> : <Sparkles size={16} />}Send sync</Button>
-                <Button variant="ghost" disabled={!!busy} onClick={() => execute('preview')}>{busy === 'preview' ? <Loader2 className="animate-spin" size={16} /> : <Eye size={16} />}Preview</Button>
-              </div>
-            </CardContent>
-          </Card>
-
-          <div className="space-y-5">
-            <SectionCard title="Delivery policy">
-              <div className="space-y-4 text-sm">
-                <PolicyRow label="Fallback" value={allowFallback ? 'Enabled' : 'Disabled'} good={allowFallback} />
-                <PolicyRow label="Consent check" value="Required" good />
-                <PolicyRow label="Quiet hours" value="22:00–08:00" />
-                <PolicyRow label="Idempotency" value={idempotencyKey ? 'Configured' : 'Not set'} good={!!idempotencyKey} />
-              </div>
-            </SectionCard>
-            <Card className="bg-primary text-primary-foreground shadow-lg shadow-primary/20">
-              <CardContent className="p-5">
-                <div className="mb-3 flex items-center gap-2 font-medium"><ShieldCheck size={17} />Safe dispatch</div>
-                <p className="text-xs leading-5 text-primary-foreground/75">Authorization, tenant isolation, consent and idempotency remain server-side responsibilities. The UI never treats client validation as security.</p>
-              </CardContent>
-            </Card>
-          </div>
+        <div className="mb-6 flex flex-wrap gap-2">
+          {steps.map((label, i) => (
+            <button
+              key={label}
+              type="button"
+              onClick={() => i <= step && setStep(i)}
+              className={`rounded-full px-3 py-1.5 text-xs font-medium transition ${
+                i === step
+                  ? 'bg-primary text-primary-foreground'
+                  : i < step
+                    ? 'bg-primary/10 text-primary'
+                    : 'bg-muted text-muted-foreground'
+              }`}
+            >
+              {i + 1}. {label}
+            </button>
+          ))}
         </div>
 
-        <div className="mt-5">
-          <SectionCard title="Recent deliveries" subtitle="Mock data until GET notification history is exposed by the API">
-            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">{notifications.slice(0, 6).map(n => <div key={n[0]} className="rounded-xl border p-4 transition duration-200 hover:-translate-y-0.5 hover:shadow-md"><div className="flex justify-between"><span className="font-mono text-[10px] text-muted-foreground">{n[0]}</span><Badge variant={n[3] === 'Delivered' ? 'success' : n[3] === 'Queued' ? 'warning' : 'danger'}>{n[3]}</Badge></div><div className="mt-3 text-sm font-medium">{n[1]}</div><div className="mt-1 text-xs text-muted-foreground">{n[2]} · {n[4]} · {n[5]}</div></div>)}</div>
+        <Card>
+          <CardContent className="space-y-6 p-6">
+            {step === 0 && (
+              <div className="space-y-4">
+                <h2 className="text-lg font-semibold">Who should receive this?</h2>
+                <Field label="Recipient">
+                  <Input
+                    value={recipient}
+                    onChange={(e) => setRecipient(e.target.value)}
+                    placeholder="User ID, phone number, or email"
+                  />
+                </Field>
+                <Field label="Channel">
+                  <Select value={channel} onChange={(e) => setChannel(e.target.value)} className="w-full">
+                    <option value="push">Push</option>
+                    <option value="sms">SMS</option>
+                    <option value="email">Email</option>
+                    <option value="webhook">Webhook</option>
+                  </Select>
+                </Field>
+              </div>
+            )}
+
+            {step === 1 && (
+              <div className="space-y-4">
+                <h2 className="text-lg font-semibold">What should they receive?</h2>
+                <Field label="Message template">
+                  <Select
+                    value={templateKey}
+                    onChange={(e) => setTemplateKey(e.target.value)}
+                    className="w-full"
+                  >
+                    <option value="">Select a template</option>
+                    {templatesQuery.data?.map((t) => (
+                      <option key={`${t.key}-${t.channel}-${t.locale}`} value={t.key}>
+                        {humanTemplateName(t.key, t.subject)} · {formatChannel(t.channel)} · {t.locale}
+                      </option>
+                    ))}
+                  </Select>
+                </Field>
+                <Field label="Language">
+                  <Input value={locale} onChange={(e) => setLocale(e.target.value)} placeholder="fa-IR" />
+                </Field>
+                {selectedTemplate && (
+                  <div className="rounded-xl border bg-muted/30 p-4 text-sm">
+                    <div className="font-medium">{humanTemplateName(selectedTemplate.key, selectedTemplate.subject)}</div>
+                    <p className="mt-2 text-muted-foreground line-clamp-3">{selectedTemplate.body}</p>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {step === 2 && (
+              <div className="space-y-4">
+                <h2 className="text-lg font-semibold">Personalize the message</h2>
+                <PersonalizationFields pairs={pairs} onChange={setPairs} />
+              </div>
+            )}
+
+            {step === 3 && (
+              <div className="space-y-4">
+                <h2 className="text-lg font-semibold">How should it be delivered?</h2>
+                <div className="grid gap-4 md:grid-cols-2">
+                  <Field label="Priority">
+                    <Select value={priority} onChange={(e) => setPriority(e.target.value)} className="w-full">
+                      <option value="low">Low</option>
+                      <option value="normal">Normal</option>
+                      <option value="high">High</option>
+                      <option value="critical">Critical</option>
+                    </Select>
+                  </Field>
+                  <Field label="Category">
+                    <Select value={category} onChange={(e) => setCategory(e.target.value)} className="w-full">
+                      <option value="transactional">Transactional</option>
+                      <option value="marketing">Marketing</option>
+                      <option value="otp">Verification</option>
+                      <option value="alert">Alert</option>
+                    </Select>
+                  </Field>
+                  <Field label="Send later (optional)">
+                    <Input type="datetime-local" value={scheduledAt} onChange={(e) => setScheduledAt(e.target.value)} />
+                  </Field>
+                  <Field label="Timezone">
+                    <Input
+                      value={timeZoneId}
+                      onChange={(e) => setTimeZoneId(e.target.value)}
+                      disabled={!scheduledAt}
+                    />
+                  </Field>
+                </div>
+                <label className="flex cursor-pointer items-start gap-3 rounded-xl border p-4">
+                  <input
+                    type="checkbox"
+                    checked={allowFallback}
+                    onChange={(e) => setAllowFallback(e.target.checked)}
+                    className="mt-1 h-4 w-4 accent-primary"
+                  />
+                  <span>
+                    <span className="block text-sm font-medium">Try another provider if the first one fails</span>
+                    <span className="mt-1 block text-xs text-muted-foreground">
+                      Recommended for important messages.
+                    </span>
+                  </span>
+                </label>
+                <button
+                  type="button"
+                  className="text-xs font-medium text-primary"
+                  onClick={() => setShowAdvanced((v) => !v)}
+                >
+                  {showAdvanced ? 'Hide advanced options' : 'Show advanced options'}
+                </button>
+                {showAdvanced && (
+                  <div className="grid gap-4 rounded-xl border border-dashed p-4 md:grid-cols-2">
+                    <Field label="Prevent duplicate sends">
+                      <Input
+                        value={idempotencyKey}
+                        onChange={(e) => setIdempotencyKey(e.target.value)}
+                        placeholder="e.g. payment-29381-success"
+                      />
+                    </Field>
+                    <Field label="Preferred provider">
+                      <Input
+                        value={preferredProvider}
+                        onChange={(e) => setPreferredProvider(e.target.value)}
+                        placeholder="Automatic"
+                      />
+                    </Field>
+                    <Field label="Collapse related messages">
+                      <Input
+                        value={collapseKey}
+                        onChange={(e) => setCollapseKey(e.target.value)}
+                        placeholder="Optional group key"
+                      />
+                    </Field>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {step === 4 && (
+              <div className="space-y-4">
+                <h2 className="text-lg font-semibold">Review before sending</h2>
+                <div className="divide-y rounded-xl border">
+                  <ReviewRow label="Recipient" value={recipient || '—'} />
+                  <ReviewRow label="Channel" value={formatChannel(channel)} />
+                  <ReviewRow
+                    label="Content"
+                    value={humanTemplateName(templateKey, selectedTemplate?.subject)}
+                  />
+                  <ReviewRow label="Language" value={locale} />
+                  <ReviewRow label="Priority" value={priority} />
+                  <ReviewRow
+                    label="When"
+                    value={scheduledAt ? `Scheduled · ${scheduledAt} (${timeZoneId})` : 'Send immediately'}
+                  />
+                  <ReviewRow
+                    label="Fallback"
+                    value={allowFallback ? 'Enabled' : 'Disabled'}
+                  />
+                  <ReviewRow
+                    label="Personalization"
+                    value={
+                      Object.entries(pairsToRecord(pairs))
+                        .map(([k, v]) => `${k}: ${v}`)
+                        .join(' · ') || 'None'
+                    }
+                  />
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  This will send a real notification to the recipient on the selected channel.
+                </p>
+              </div>
+            )}
+
+            <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-5">
+              <Button
+                variant="ghost"
+                disabled={step === 0 || !!busy}
+                onClick={() => setStep((s) => Math.max(0, s - 1))}
+              >
+                <ChevronLeft size={16} /> Back
+              </Button>
+              <div className="flex flex-wrap gap-2">
+                {step < steps.length - 1 ? (
+                  <Button disabled={!canNext()} onClick={() => setStep((s) => s + 1)}>
+                    Continue <ChevronRight size={16} />
+                  </Button>
+                ) : (
+                  <>
+                    <Button variant="ghost" disabled={!!busy} onClick={() => execute('preview')}>
+                      {busy === 'preview' ? <Loader2 className="animate-spin" size={16} /> : <Eye size={16} />}
+                      Preview
+                    </Button>
+                    <Button variant="outline" disabled={!!busy} onClick={() => execute('wait')}>
+                      {busy === 'wait' ? <Loader2 className="animate-spin" size={16} /> : <Send size={16} />}
+                      Send and wait for result
+                    </Button>
+                    <Button disabled={!!busy} onClick={() => execute('send')}>
+                      {busy === 'send' ? <Loader2 className="animate-spin" size={16} /> : <Send size={16} />}
+                      Send now
+                    </Button>
+                  </>
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="mt-6">
+          <SectionCard title="Recent activity" subtitle="Sample deliveries for orientation">
+            <div className="space-y-3">
+              {[
+                ['OTP verification', 'push', 'Delivered', '•••2214'],
+                ['Payment successful', 'sms', 'Delivered', '•••0871'],
+                ['Invoice ready', 'email', 'Queued', 'user@domain.com'],
+              ].map((n) => (
+                <div key={n[0]} className="flex items-center justify-between rounded-xl border p-3 text-sm">
+                  <div>
+                    <div className="font-medium">{n[0]}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {formatChannel(n[1])} · {n[3]}
+                    </div>
+                  </div>
+                  <StatusPill status={n[2]} />
+                </div>
+              ))}
+            </div>
           </SectionCard>
         </div>
       </div>
@@ -184,10 +398,20 @@ export default function Notifications() {
   )
 }
 
-function Field({ label, required, hint, children }: { label: string; required?: boolean; hint?: string; children: React.ReactNode }) {
-  return <label className="space-y-2 text-sm"><span className="flex items-center gap-2 font-medium">{label}{required && <span className="text-destructive">*</span>}{hint && <span className="text-[10px] font-normal text-muted-foreground">{hint}</span>}</span>{children}</label>
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-2 text-sm">
+      <span className="font-medium">{label}</span>
+      {children}
+    </label>
+  )
 }
 
-function PolicyRow({ label, value, good }: { label: string; value: string; good?: boolean }) {
-  return <div className="flex items-center justify-between gap-4"><span className="text-muted-foreground">{label}</span><Badge variant={good ? 'success' : 'outline'}>{value}</Badge></div>
+function ReviewRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:justify-between">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="text-sm font-medium sm:text-right">{value}</span>
+    </div>
+  )
 }

--- a/apps/admin/app/notifications/status/page.tsx
+++ b/apps/admin/app/notifications/status/page.tsx
@@ -1,11 +1,101 @@
 'use client'
+
 import { useState } from 'react'
-import { Activity, CheckCircle2, Clock3, Search, XCircle } from 'lucide-react'
+import { Activity, CheckCircle2, Search, XCircle } from 'lucide-react'
 import { PageHeader } from '@/components/page-header'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { useNotificationStatus } from '@/hooks/use-notification-status'
-export default function StatusPage(){const [id,setId]=useState('');const [query,setQuery]=useState('');const q=useNotificationStatus(query||undefined);const status=String((q.data as any)?.status??'Unknown');const terminal=['delivered','failed','cancelled','rejected'].includes(status.toLowerCase());return <div className="grid-bg min-h-full p-5 md:p-8"><div className="mx-auto max-w-[1100px]"><PageHeader eyebrow="Operations" title="Notification status" description="Inspect a notification by ID. Active requests are polled until a terminal delivery state."/><Card><CardContent className="p-5"><div className="flex gap-2"><Input value={id} onChange={e=>setId(e.target.value)} placeholder="Notification UUID" className="font-mono"/><Button onClick={()=>setQuery(id.trim())} disabled={!id.trim()}><Search size={16}/>Inspect</Button></div></CardContent></Card>{query&&<div className="mt-5 grid gap-5 md:grid-cols-[1fr_300px]"><Card><CardHeader><div className="flex items-center justify-between"><CardTitle>Delivery state</CardTitle><Badge variant={terminal?(status.toLowerCase()==='delivered'?'success':'danger'):'warning'}>{status}</Badge></div></CardHeader><CardContent><div className="flex items-center gap-4 py-8"><StateIcon status={status}/><div><div className="font-mono text-xs text-muted-foreground">{query}</div><div className="mt-1 text-xl font-semibold">{status}</div><p className="mt-1 text-sm text-muted-foreground">{q.isFetching?'Refreshing from NotificationHub…':q.isError?'Unable to retrieve this notification.':'Latest server state'}</p></div></div></CardContent></Card><Card><CardHeader><CardTitle>Polling</CardTitle></CardHeader><CardContent className="space-y-4 text-sm"><Row icon={Activity} label="Auto refresh" value={terminal?'Stopped':'2.5s'}/><Row icon={Clock3} label="Source" value="GET /notifications/{id}"/><Row icon={CheckCircle2} label="Terminal" value={terminal?'Yes':'No'}/></CardContent></Card></div>}</div></div>}
-function StateIcon({status}:{status:string}){const s=status.toLowerCase();if(s==='delivered')return <CheckCircle2 className="text-emerald-500" size={38}/>;if(['failed','rejected','cancelled'].includes(s))return <XCircle className="text-destructive" size={38}/>;return <Activity className="animate-pulse text-primary" size={38}/>} function Row({icon:Icon,label,value}:{icon:any;label:string;value:string}){return <div className="flex items-center justify-between"><span className="flex items-center gap-2 text-muted-foreground"><Icon size={15}/>{label}</span><span className="font-medium">{value}</span></div>}
+import { formatChannel, formatDateTime, formatStatus, statusTone } from '@/lib/ux/labels'
+
+export default function StatusPage() {
+  const [id, setId] = useState('')
+  const [query, setQuery] = useState('')
+  const q = useNotificationStatus(query || undefined)
+  const data = (q.data ?? {}) as Record<string, unknown>
+  const status = String(data.status ?? 'Unknown')
+  const terminal = ['delivered', 'failed', 'cancelled', 'rejected'].includes(status.toLowerCase())
+
+  return (
+    <div className="grid-bg min-h-full p-5 md:p-8">
+      <div className="mx-auto max-w-[1100px]">
+        <PageHeader
+          eyebrow="Operations"
+          title="Delivery status"
+          description="Look up a single message and see whether it was delivered."
+        />
+        <Card>
+          <CardContent className="p-5">
+            <div className="flex gap-2">
+              <Input value={id} onChange={(e) => setId(e.target.value)} placeholder="Message reference" />
+              <Button onClick={() => setQuery(id.trim())} disabled={!id.trim()}>
+                <Search size={16} /> Look up
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        {query && (
+          <div className="mt-5 grid gap-5 md:grid-cols-[1fr_280px]">
+            <Card>
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <CardTitle>Message</CardTitle>
+                  <Badge variant={statusTone(status)}>{formatStatus(status)}</Badge>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center gap-4 py-6">
+                  <StateIcon status={status} />
+                  <div>
+                    <div className="text-xl font-semibold">{formatStatus(status)}</div>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {q.isFetching
+                        ? 'Refreshing…'
+                        : q.isError
+                          ? 'This message could not be found or loaded.'
+                          : terminal
+                            ? 'Final state'
+                            : 'Still in progress — this view updates automatically'}
+                    </p>
+                  </div>
+                </div>
+                <dl className="grid gap-3 border-t pt-4 text-sm sm:grid-cols-2">
+                  <Row label="Recipient" value={String(data.recipient ?? '—')} />
+                  <Row label="Channel" value={formatChannel(String(data.channel ?? ''))} />
+                  <Row label="Template" value={String(data.templateKey ?? data.template ?? '—')} />
+                  <Row label="Created" value={formatDateTime(String(data.createdAt ?? data.scheduledAt ?? ''))} />
+                  <Row label="Provider" value={String(data.provider ?? data.preferredProvider ?? '—')} />
+                </dl>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader><CardTitle>Tracking</CardTitle></CardHeader>
+              <CardContent className="space-y-3 text-sm text-muted-foreground">
+                <p>{terminal ? 'Updates stopped — delivery finished.' : 'Checking every few seconds for changes.'}</p>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function StateIcon({ status }: { status: string }) {
+  const s = status.toLowerCase()
+  if (s === 'delivered') return <CheckCircle2 className="text-emerald-500" size={38} />
+  if (['failed', 'rejected', 'cancelled'].includes(s)) return <XCircle className="text-destructive" size={38} />
+  return <Activity className="animate-pulse text-primary" size={38} />
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-xs text-muted-foreground">{label}</dt>
+      <dd className="mt-0.5 font-medium">{value || '—'}</dd>
+    </div>
+  )
+}

--- a/apps/admin/app/organization/members/page.tsx
+++ b/apps/admin/app/organization/members/page.tsx
@@ -47,8 +47,7 @@ export default function MembersPage() {
           </div>
         )}
         {orgId && can(Perm.MemberInvite) && (
-          <SectionCard className="mb-6">
-            <div className="mb-3 text-sm font-medium">Invite member</div>
+          <SectionCard title="Invite member" className="mb-6">
             <div className="flex flex-col gap-3 sm:flex-row">
               <input
                 className="flex-1 rounded-xl border bg-background px-3 py-2 text-sm"
@@ -65,20 +64,15 @@ export default function MembersPage() {
                 <option>Operator</option>
                 <option>OrganizationAdmin</option>
               </select>
-              <Button
-                disabled={!email || invite.isPending}
-                onClick={() => invite.mutate()}
-              >
+              <Button disabled={!email || invite.isPending} onClick={() => invite.mutate()}>
                 Send invite
               </Button>
             </div>
-            {invite.isError && (
-              <p className="mt-2 text-xs text-destructive">Invite failed</p>
-            )}
+            {invite.isError && <p className="mt-2 text-xs text-destructive">Invite failed</p>}
           </SectionCard>
         )}
         {orgId && (
-          <SectionCard>
+          <SectionCard title="Team members">
             <div className="overflow-x-auto">
               <table className="w-full text-left text-sm">
                 <thead className="text-xs uppercase text-muted-foreground">

--- a/apps/admin/app/organization/members/page.tsx
+++ b/apps/admin/app/organization/members/page.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { PageHeader } from '@/components/page-header'
+import { SectionCard } from '@/components/section-card'
+import { Button } from '@/components/ui/button'
+import { RequirePermission } from '@/components/require-auth'
+import { useAuth } from '@/providers/auth-provider'
+import { identityApi } from '@/lib/api/identity'
+import { Perm } from '@/lib/auth/permissions'
+
+export default function MembersPage() {
+  const { me, can } = useAuth()
+  const orgId = me?.tenant?.id
+  const qc = useQueryClient()
+  const [email, setEmail] = useState('')
+  const [roleName, setRoleName] = useState('Viewer')
+
+  const members = useQuery({
+    queryKey: ['org', orgId, 'members'],
+    queryFn: () => identityApi.listMembers(orgId!),
+    enabled: !!orgId,
+  })
+
+  const invite = useMutation({
+    mutationFn: () => identityApi.invite({ email, roleName, organizationId: orgId }),
+    onSuccess: () => {
+      setEmail('')
+      void qc.invalidateQueries({ queryKey: ['org', orgId, 'members'] })
+    },
+  })
+
+  const setStatus = useMutation({
+    mutationFn: ({ membershipId, status }: { membershipId: string; status: string }) =>
+      identityApi.setMemberStatus(orgId!, membershipId, status),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ['org', orgId, 'members'] }),
+  })
+
+  return (
+    <div className="p-6 lg:p-8">
+      <PageHeader title="Members" description="Invite teammates and manage organization roles." />
+      <RequirePermission permission={Perm.MemberRead}>
+        {!orgId && (
+          <div className="mb-4 rounded-xl border p-4 text-sm text-muted-foreground">
+            Select an organization from the top bar to manage members.
+          </div>
+        )}
+        {orgId && can(Perm.MemberInvite) && (
+          <SectionCard className="mb-6">
+            <div className="mb-3 text-sm font-medium">Invite member</div>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <input
+                className="flex-1 rounded-xl border bg-background px-3 py-2 text-sm"
+                placeholder="email@company.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+              <select
+                className="rounded-xl border bg-background px-3 py-2 text-sm"
+                value={roleName}
+                onChange={(e) => setRoleName(e.target.value)}
+              >
+                <option>Viewer</option>
+                <option>Operator</option>
+                <option>OrganizationAdmin</option>
+              </select>
+              <Button
+                disabled={!email || invite.isPending}
+                onClick={() => invite.mutate()}
+              >
+                Send invite
+              </Button>
+            </div>
+            {invite.isError && (
+              <p className="mt-2 text-xs text-destructive">Invite failed</p>
+            )}
+          </SectionCard>
+        )}
+        {orgId && (
+          <SectionCard>
+            <div className="overflow-x-auto">
+              <table className="w-full text-left text-sm">
+                <thead className="text-xs uppercase text-muted-foreground">
+                  <tr>
+                    <th className="pb-3 pr-4">User</th>
+                    <th className="pb-3 pr-4">Status</th>
+                    <th className="pb-3 pr-4">Roles</th>
+                    <th className="pb-3">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(members.data ?? []).map((m) => (
+                    <tr key={m.membershipId} className="border-t">
+                      <td className="py-3 pr-4">
+                        <div className="font-medium">{m.displayName || m.email}</div>
+                        <div className="text-xs text-muted-foreground">{m.email}</div>
+                      </td>
+                      <td className="py-3 pr-4">{m.status}</td>
+                      <td className="py-3 pr-4">{m.roles.join(', ') || '—'}</td>
+                      <td className="py-3">
+                        {can(Perm.MemberSuspend) && m.status === 'Active' && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setStatus.mutate({ membershipId: m.membershipId, status: 'Suspended' })}
+                          >
+                            Suspend
+                          </Button>
+                        )}
+                        {can(Perm.MemberSuspend) && m.status === 'Suspended' && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setStatus.mutate({ membershipId: m.membershipId, status: 'Active' })}
+                          >
+                            Reactivate
+                          </Button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {members.isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+            </div>
+          </SectionCard>
+        )}
+      </RequirePermission>
+    </div>
+  )
+}

--- a/apps/admin/app/organization/settings/page.tsx
+++ b/apps/admin/app/organization/settings/page.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { PageHeader } from '@/components/page-header'
+import { SectionCard } from '@/components/section-card'
+import { Button } from '@/components/ui/button'
+import { RequirePermission } from '@/components/require-auth'
+import { useAuth } from '@/providers/auth-provider'
+import { identityApi } from '@/lib/api/identity'
+import { Perm } from '@/lib/auth/permissions'
+
+export default function OrgSettingsPage() {
+  const { me } = useAuth()
+  const orgId = me?.tenant?.id
+  const qc = useQueryClient()
+  const [name, setName] = useState('')
+
+  const org = useQuery({
+    queryKey: ['org', orgId],
+    queryFn: () => identityApi.getOrganization(orgId!),
+    enabled: !!orgId,
+  })
+
+  useEffect(() => {
+    if (org.data?.name) setName(org.data.name)
+  }, [org.data?.name])
+
+  const save = useMutation({
+    mutationFn: () => identityApi.updateOrganization(orgId!, { name }),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ['org', orgId] }),
+  })
+
+  return (
+    <div className="p-6 lg:p-8">
+      <PageHeader title="Organization" description="Organization profile and status." />
+      <RequirePermission permission={Perm.OrganizationRead}>
+        {!orgId && (
+          <p className="text-sm text-muted-foreground">No active organization in session.</p>
+        )}
+        {org.data && (
+          <SectionCard>
+            <div className="grid gap-4 max-w-lg">
+              <label className="text-sm">
+                <span className="mb-1 block text-muted-foreground">Name</span>
+                <input
+                  className="w-full rounded-xl border bg-background px-3 py-2"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  disabled={!me?.permissions.includes(Perm.OrganizationUpdate)}
+                />
+              </label>
+              <div className="text-sm">
+                <span className="text-muted-foreground">Status: </span>
+                {org.data.status}
+              </div>
+              <div className="text-sm">
+                <span className="text-muted-foreground">Type: </span>
+                {org.data.type}
+              </div>
+              {me?.permissions.includes(Perm.OrganizationUpdate) && (
+                <Button disabled={save.isPending || name === org.data.name} onClick={() => save.mutate()}>
+                  Save changes
+                </Button>
+              )}
+            </div>
+          </SectionCard>
+        )}
+      </RequirePermission>
+    </div>
+  )
+}

--- a/apps/admin/app/organization/settings/page.tsx
+++ b/apps/admin/app/organization/settings/page.tsx
@@ -39,8 +39,8 @@ export default function OrgSettingsPage() {
           <p className="text-sm text-muted-foreground">No active organization in session.</p>
         )}
         {org.data && (
-          <SectionCard>
-            <div className="grid gap-4 max-w-lg">
+          <SectionCard title="Profile">
+            <div className="grid max-w-lg gap-4">
               <label className="text-sm">
                 <span className="mb-1 block text-muted-foreground">Name</span>
                 <input

--- a/apps/admin/app/plugins/page.tsx
+++ b/apps/admin/app/plugins/page.tsx
@@ -1,3 +1,98 @@
 'use client'
-import {useState} from 'react'; import {PageHeader} from '@/components/page-header'; import {Card,CardContent,CardHeader,CardTitle} from '@/components/ui/card'; import {Button} from '@/components/ui/button'; import {resourcesApi} from '@/lib/api/resources'; import {OperationPanel} from '@/components/operation-panel';
-export default function Page(){const [result,setResult]=useState<unknown>();const check=async()=>setResult(await resourcesApi.messagingHealth());return <div className="grid-bg min-h-full p-5 md:p-8"><div className="mx-auto max-w-[1000px]"><PageHeader eyebrow="Platform" title="Plugins & Messaging" description="Inspect registered providers and validate messaging infrastructure health."/><div className="grid gap-5 md:grid-cols-2"><OperationPanel title="Messaging health" description="GET /api/v1/admin/messaging/health" onSubmit={check} label="Check health"><p className="text-sm text-muted-foreground">The response is rendered in the inspection panel below.</p></OperationPanel><Card><CardHeader><CardTitle>Provider model</CardTitle></CardHeader><CardContent className="space-y-3 text-sm text-muted-foreground"><p>Plugin discovery is exposed by <code>GET /api/v1/plugins</code>.</p><p>Provider selection can be controlled by <code>preferredProvider</code> and <code>allowFallback</code> at notification level.</p></CardContent></Card></div>{result!==undefined&&<Card className="mt-5"><CardHeader><CardTitle>Health response</CardTitle></CardHeader><CardContent><pre className="overflow-auto rounded-xl bg-muted p-4 text-xs">{JSON.stringify(result,null,2)}</pre></CardContent></Card>}</div></div>}
+
+import { useState } from 'react'
+import { PageHeader } from '@/components/page-header'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { ToastHost } from '@/components/toast-host'
+import { resourcesApi } from '@/lib/api/resources'
+import { formatStatus, friendlyError, statusTone } from '@/lib/ux/labels'
+
+export default function PluginsPage() {
+  const [plugins, setPlugins] = useState<Array<Record<string, unknown>>>([])
+  const [health, setHealth] = useState<Record<string, unknown> | null>(null)
+  const [toast, setToast] = useState<{ tone: 'success' | 'error'; title: string; description?: string } | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  async function loadPlugins() {
+    setBusy(true)
+    try {
+      const res = (await resourcesApi.plugins()) as Array<Record<string, unknown>>
+      setPlugins(Array.isArray(res) ? res : [])
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not load integrations', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function checkHealth() {
+    setBusy(true)
+    try {
+      const res = (await resourcesApi.messagingHealth()) as Record<string, unknown>
+      setHealth(res)
+      setToast({ tone: 'success', title: 'Health check complete' })
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Health check failed', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const overall = String(health?.status ?? health?.overall ?? health?.State ?? '')
+
+  return (
+    <div className="grid-bg min-h-full p-5 md:p-8">
+      <ToastHost toast={toast} onClose={() => setToast(null)} />
+      <div className="mx-auto max-w-[1000px]">
+        <PageHeader
+          eyebrow="Integrations"
+          title="Providers & health"
+          description="See which delivery providers are available and whether messaging is healthy."
+        />
+
+        <div className="mb-5 flex flex-wrap gap-2">
+          <Button disabled={busy} onClick={() => void loadPlugins()}>Refresh providers</Button>
+          <Button disabled={busy} variant="outline" onClick={() => void checkHealth()}>Check messaging health</Button>
+        </div>
+
+        {health && (
+          <Card className="mb-5">
+            <CardContent className="flex items-center justify-between gap-4 p-6">
+              <div>
+                <div className="text-sm text-muted-foreground">Messaging infrastructure</div>
+                <div className="mt-1 text-lg font-semibold">{formatStatus(overall) || 'Checked'}</div>
+              </div>
+              <Badge variant={statusTone(overall)}>{formatStatus(overall) || 'OK'}</Badge>
+            </CardContent>
+          </Card>
+        )}
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          {plugins.length === 0 && (
+            <p className="text-sm text-muted-foreground col-span-full">No providers loaded yet. Press “Refresh providers”.</p>
+          )}
+          {plugins.map((p, i) => {
+            const name = String(p.name ?? p.Name ?? p.id ?? p.Id ?? `Provider ${i + 1}`)
+            const channel = String(p.channel ?? p.Channel ?? p.capability ?? '')
+            const status = String(p.status ?? p.Status ?? p.health ?? 'available')
+            return (
+              <Card key={i}>
+                <CardContent className="p-5">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <div className="font-semibold">{name}</div>
+                      {channel && <div className="mt-1 text-xs text-muted-foreground">{channel}</div>}
+                    </div>
+                    <Badge variant={statusTone(status)}>{formatStatus(status)}</Badge>
+                  </div>
+                </CardContent>
+              </Card>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/admin/app/preferences/page.tsx
+++ b/apps/admin/app/preferences/page.tsx
@@ -1,3 +1,148 @@
 'use client'
-import {useState} from 'react'; import {PageHeader} from '@/components/page-header'; import {Input} from '@/components/ui/input'; import {Select} from '@/components/ui/select'; import {Button} from '@/components/ui/button'; import {resourcesApi} from '@/lib/api/resources'; import {useTenant} from '@/providers/tenant-provider'; import {OperationPanel,Field} from '@/components/operation-panel';
-export default function Page(){const {tenantId}=useTenant();const [userId,setUserId]=useState('');const [preferredChannel,setPreferredChannel]=useState('push');const [start,setStart]=useState('22:00');const [end,setEnd]=useState('08:00');const [max,setMax]=useState('12');const [locale,setLocale]=useState('fa-IR');const [channels,setChannels]=useState('{"push":true,"email":true,"sms":false}');return <div className="grid-bg min-h-full p-5 md:p-8"><div className="mx-auto max-w-[1100px]"><PageHeader eyebrow="Audience" title="Preferences" description="Persist channel opt-ins, preferred delivery, quiet hours and frequency controls."/><div className="grid gap-5 lg:grid-cols-2"><OperationPanel title="Save preferences" description="PUT /api/v1/preferences" onSubmit={()=>resourcesApi.preferences.save({userId,tenantId,preferredChannel,quietHoursStart:start,quietHoursEnd:end,maxPerDay:Number(max),timeZoneId:'Asia/Tehran',channelOptIn:JSON.parse(channels),updatedAt:new Date().toISOString()})}><Field label="User ID"><Input value={userId} onChange={e=>setUserId(e.target.value)}/></Field><Field label="Preferred channel"><Select value={preferredChannel} onChange={e=>setPreferredChannel(e.target.value)}><option>push</option><option>email</option><option>sms</option><option>webhook</option></Select></Field><div className="grid grid-cols-2 gap-3"><Field label="Quiet start"><Input value={start} onChange={e=>setStart(e.target.value)}/></Field><Field label="Quiet end"><Input value={end} onChange={e=>setEnd(e.target.value)}/></Field></div><Field label="Max per day"><Input type="number" value={max} onChange={e=>setMax(e.target.value)}/></Field><Field label="Channel opt-in" hint="JSON"><Input value={channels} onChange={e=>setChannels(e.target.value)}/></Field></OperationPanel><OperationPanel title="Get preferences" description="GET /api/v1/preferences/{userId}" onSubmit={()=>resourcesApi.preferences.get(userId,tenantId)} label="Fetch"><Field label="User ID"><Input value={userId} onChange={e=>setUserId(e.target.value)}/></Field></OperationPanel></div></div></div>}
+
+import { useState } from 'react'
+import { PageHeader } from '@/components/page-header'
+import { Input } from '@/components/ui/input'
+import { Select } from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { ToastHost } from '@/components/toast-host'
+import { resourcesApi } from '@/lib/api/resources'
+import { useTenant } from '@/providers/tenant-provider'
+import { formatChannel, friendlyError } from '@/lib/ux/labels'
+
+export default function PreferencesPage() {
+  const { tenantId } = useTenant()
+  const [userId, setUserId] = useState('')
+  const [preferredChannel, setPreferredChannel] = useState('push')
+  const [start, setStart] = useState('22:00')
+  const [end, setEnd] = useState('08:00')
+  const [max, setMax] = useState('12')
+  const [optIn, setOptIn] = useState({ push: true, email: true, sms: false, webhook: false })
+  const [toast, setToast] = useState<{ tone: 'success' | 'error'; title: string; description?: string } | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [loaded, setLoaded] = useState(false)
+
+  async function save() {
+    setBusy(true)
+    try {
+      await resourcesApi.preferences.save({
+        userId,
+        tenantId,
+        preferredChannel,
+        quietHoursStart: start,
+        quietHoursEnd: end,
+        maxPerDay: Number(max),
+        timeZoneId: 'Asia/Tehran',
+        channelOptIn: optIn,
+        updatedAt: new Date().toISOString(),
+      })
+      setToast({ tone: 'success', title: 'Preferences saved' })
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not save preferences', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function load() {
+    setBusy(true)
+    try {
+      const res = (await resourcesApi.preferences.get(userId, tenantId)) as Record<string, unknown>
+      if (res.preferredChannel) setPreferredChannel(String(res.preferredChannel))
+      if (res.quietHoursStart) setStart(String(res.quietHoursStart))
+      if (res.quietHoursEnd) setEnd(String(res.quietHoursEnd))
+      if (res.maxPerDay != null) setMax(String(res.maxPerDay))
+      if (res.channelOptIn && typeof res.channelOptIn === 'object') {
+        setOptIn((prev) => ({ ...prev, ...(res.channelOptIn as Record<string, boolean>) }))
+      }
+      setLoaded(true)
+      setToast({ tone: 'success', title: 'Preferences loaded' })
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not load preferences', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="grid-bg min-h-full p-5 md:p-8">
+      <ToastHost toast={toast} onClose={() => setToast(null)} />
+      <div className="mx-auto max-w-[900px]">
+        <PageHeader
+          eyebrow="Audience"
+          title="Notification preferences"
+          description="Control how and when a person receives messages."
+        />
+        <Card>
+          <CardContent className="space-y-6 p-6">
+            <Field label="User">
+              <div className="flex gap-2">
+                <Input value={userId} onChange={(e) => setUserId(e.target.value)} placeholder="User ID" className="flex-1" />
+                <Button variant="outline" disabled={!userId || busy} onClick={() => void load()}>
+                  Load
+                </Button>
+              </div>
+            </Field>
+
+            <section>
+              <h3 className="mb-3 text-sm font-semibold">Channels</h3>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {(['push', 'email', 'sms', 'webhook'] as const).map((c) => (
+                  <label key={c} className="flex cursor-pointer items-center gap-3 rounded-xl border p-3 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={!!optIn[c]}
+                      onChange={(e) => setOptIn((o) => ({ ...o, [c]: e.target.checked }))}
+                      className="h-4 w-4 accent-primary"
+                    />
+                    Allow {formatChannel(c)}
+                  </label>
+                ))}
+              </div>
+            </section>
+
+            <Field label="Preferred channel">
+              <Select value={preferredChannel} onChange={(e) => setPreferredChannel(e.target.value)} className="w-full">
+                <option value="push">Push</option>
+                <option value="email">Email</option>
+                <option value="sms">SMS</option>
+                <option value="webhook">Webhook</option>
+              </Select>
+            </Field>
+
+            <section>
+              <h3 className="mb-3 text-sm font-semibold">Quiet hours</h3>
+              <p className="mb-3 text-xs text-muted-foreground">Messages are held during this window (server timezone rules apply).</p>
+              <div className="grid grid-cols-2 gap-3">
+                <Field label="From"><Input value={start} onChange={(e) => setStart(e.target.value)} placeholder="22:00" /></Field>
+                <Field label="Until"><Input value={end} onChange={(e) => setEnd(e.target.value)} placeholder="08:00" /></Field>
+              </div>
+            </section>
+
+            <Field label="Daily limit" hint="Maximum messages per day">
+              <Input type="number" min={0} value={max} onChange={(e) => setMax(e.target.value)} />
+            </Field>
+
+            <Button disabled={busy || !userId} onClick={() => void save()}>
+              Save preferences
+            </Button>
+            {loaded && <p className="text-xs text-muted-foreground">Showing last loaded values for this user.</p>}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-2 text-sm">
+      <span className="flex gap-2 font-medium">
+        {label}
+        {hint && <span className="text-[10px] font-normal text-muted-foreground">{hint}</span>}
+      </span>
+      {children}
+    </label>
+  )
+}

--- a/apps/admin/app/segments/page.tsx
+++ b/apps/admin/app/segments/page.tsx
@@ -1,3 +1,178 @@
 'use client'
-import {useState} from 'react'; import {PageHeader} from '@/components/page-header'; import {Card,CardContent,CardHeader,CardTitle} from '@/components/ui/card'; import {Input} from '@/components/ui/input'; import {Select} from '@/components/ui/select'; import {Button} from '@/components/ui/button'; import {resourcesApi} from '@/lib/api/resources'; import {useTenant} from '@/providers/tenant-provider'; import {OperationPanel,Field} from '@/components/operation-panel';
-export default function Page(){const {tenantId}=useTenant();const [key,setKey]=useState('high-value-users');const [field,setField]=useState('purchaseAmount');const [operator,setOperator]=useState('gt');const [value,setValue]=useState('5000000');const [matchAll,setMatchAll]=useState(true);const [payload,setPayload]=useState('{"purchaseAmount":7000000}');return <div className="grid-bg min-h-full p-5 md:p-8"><div className="mx-auto max-w-[1200px]"><PageHeader eyebrow="Audience" title="Segments" description="Define reusable recipient cohorts and test arbitrary audience attributes against a segment."/><div className="grid gap-5 lg:grid-cols-2"><OperationPanel title="Segment definition" description="POST /api/v1/segments" onSubmit={()=>resourcesApi.segments.save({key,tenantId,matchAll,rules:[{field,operator,value}]})}><Field label="Key"><Input value={key} onChange={e=>setKey(e.target.value)}/></Field><div className="grid gap-3 md:grid-cols-3"><Field label="Field"><Input value={field} onChange={e=>setField(e.target.value)}/></Field><Field label="Operator"><Select value={operator} onChange={e=>setOperator(e.target.value)}><option value="eq">equals</option><option value="neq">not equals</option><option value="gt">greater than</option><option value="gte">greater/equal</option><option value="lt">less than</option><option value="contains">contains</option></Select></Field><Field label="Value"><Input value={value} onChange={e=>setValue(e.target.value)}/></Field></div><Button type="button" variant="outline" onClick={()=>setMatchAll(v=>!v)}>Match {matchAll?'ALL':'ANY'} rules</Button></OperationPanel><OperationPanel title="Match segment" description="POST /api/v1/segments/{key}/match" onSubmit={()=>resourcesApi.segments.match(key,JSON.parse(payload),tenantId)} label="Evaluate"><Field label="Subject attributes" hint="JSON"><textarea value={payload} onChange={e=>setPayload(e.target.value)} className="min-h-48 w-full rounded-xl border bg-background p-3 font-mono text-xs"/></Field></OperationPanel></div></div></div>}
+
+import { useState } from 'react'
+import { Plus, Trash2 } from 'lucide-react'
+import { PageHeader } from '@/components/page-header'
+import { Input } from '@/components/ui/input'
+import { Select } from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent } from '@/components/ui/card'
+import { resourcesApi } from '@/lib/api/resources'
+import { useTenant } from '@/providers/tenant-provider'
+import { ToastHost } from '@/components/toast-host'
+import { KeyValueEditor, pairsToRecord, type KeyValuePair } from '@/components/key-value-editor'
+import { friendlyError, humanizeKey } from '@/lib/ux/labels'
+import type { SegmentRule } from '@/types/api'
+
+const operatorLabel: Record<string, string> = {
+  eq: 'equals',
+  neq: 'does not equal',
+  gt: 'is greater than',
+  gte: 'is at least',
+  lt: 'is less than',
+  lte: 'is at most',
+  contains: 'contains',
+}
+
+export default function SegmentsPage() {
+  const { tenantId } = useTenant()
+  const [name, setName] = useState('High value customers')
+  const [key, setKey] = useState('high-value-users')
+  const [rules, setRules] = useState<SegmentRule[]>([{ field: 'purchaseAmount', operator: 'gt', value: '5000000' }])
+  const [matchAll, setMatchAll] = useState(true)
+  const [testPairs, setTestPairs] = useState<KeyValuePair[]>([{ key: 'purchaseAmount', value: '7000000' }])
+  const [matchResult, setMatchResult] = useState<boolean | null>(null)
+  const [toast, setToast] = useState<{ tone: 'success' | 'error'; title: string; description?: string } | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  function updateRule(i: number, patch: Partial<SegmentRule>) {
+    setRules((r) => r.map((x, idx) => (idx === i ? { ...x, ...patch } : x)))
+  }
+
+  async function save() {
+    setBusy(true)
+    try {
+      await resourcesApi.segments.save({ key, tenantId, matchAll, rules })
+      setToast({ tone: 'success', title: 'Audience saved', description: `“${name || humanizeKey(key)}” is ready to use.` })
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not save audience', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function testMatch() {
+    setBusy(true)
+    setMatchResult(null)
+    try {
+      const res = (await resourcesApi.segments.match(key, pairsToRecord(testPairs), tenantId)) as { matched?: boolean } | boolean
+      const matched = typeof res === 'boolean' ? res : Boolean(res?.matched ?? res)
+      setMatchResult(matched)
+      setToast({
+        tone: 'success',
+        title: matched ? 'This person matches' : 'This person does not match',
+      })
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not test audience', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="grid-bg min-h-full p-5 md:p-8">
+      <ToastHost toast={toast} onClose={() => setToast(null)} />
+      <div className="mx-auto max-w-[1100px]">
+        <PageHeader
+          eyebrow="Content"
+          title="Audiences"
+          description="Define who belongs in a group — for campaigns and broadcasts."
+        />
+
+        <div className="grid gap-5 lg:grid-cols-2">
+          <Card>
+            <CardContent className="space-y-5 p-6">
+              <h2 className="font-semibold">Audience rules</h2>
+              <Field label="Display name">
+                <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="High value customers" />
+              </Field>
+              <Field label="Internal code" hint="Used by the system">
+                <Input value={key} onChange={(e) => setKey(e.target.value)} />
+              </Field>
+
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium">People where</span>
+                  <Button type="button" size="sm" variant="outline" onClick={() => setMatchAll((v) => !v)}>
+                    Match {matchAll ? 'all' : 'any'} rules
+                  </Button>
+                </div>
+                {rules.map((r, i) => (
+                  <div key={i} className="rounded-xl border bg-muted/20 p-3">
+                    <div className="mb-2 flex items-center justify-between text-xs text-muted-foreground">
+                      <span>Rule {i + 1}{i > 0 ? ` · ${matchAll ? 'AND' : 'OR'}` : ''}</span>
+                      <Button type="button" size="icon" variant="ghost" onClick={() => setRules((x) => x.filter((_, j) => j !== i))}>
+                        <Trash2 size={14} />
+                      </Button>
+                    </div>
+                    <div className="grid gap-2 sm:grid-cols-3">
+                      <Input value={r.field} onChange={(e) => updateRule(i, { field: e.target.value })} placeholder="Attribute" />
+                      <Select value={r.operator} onChange={(e) => updateRule(i, { operator: e.target.value })}>
+                        {Object.entries(operatorLabel).map(([k, label]) => (
+                          <option key={k} value={k}>{label}</option>
+                        ))}
+                      </Select>
+                      <Input value={r.value} onChange={(e) => updateRule(i, { value: e.target.value })} placeholder="Value" />
+                    </div>
+                  </div>
+                ))}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setRules((r) => [...r, { field: '', operator: 'eq', value: '' }])}
+                >
+                  <Plus size={14} /> Add rule
+                </Button>
+              </div>
+
+              <div className="rounded-xl border border-dashed p-3 text-sm text-muted-foreground">
+                Summary:{' '}
+                {rules.map((r, i) => (
+                  <span key={i}>
+                    {i > 0 && <strong> {matchAll ? 'and' : 'or'} </strong>}
+                    <strong>{r.field || '…'}</strong> {operatorLabel[r.operator] || r.operator}{' '}
+                    <strong>{r.value || '…'}</strong>
+                  </span>
+                ))}
+              </div>
+
+              <Button disabled={busy || !key} onClick={() => void save()}>
+                Save audience
+              </Button>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent className="space-y-5 p-6">
+              <h2 className="font-semibold">Test a person</h2>
+              <p className="text-sm text-muted-foreground">Enter sample attributes to see if they would be included.</p>
+              <KeyValueEditor pairs={testPairs} onChange={setTestPairs} keyPlaceholder="Attribute" valuePlaceholder="Value" />
+              <Button disabled={busy || !key} variant="outline" onClick={() => void testMatch()}>
+                Check match
+              </Button>
+              {matchResult !== null && (
+                <Badge variant={matchResult ? 'success' : 'danger'}>
+                  {matchResult ? 'Matches this audience' : 'Does not match'}
+                </Badge>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-2 text-sm">
+      <span className="flex gap-2 font-medium">
+        {label}
+        {hint && <span className="text-[10px] font-normal text-muted-foreground">{hint}</span>}
+      </span>
+      {children}
+    </label>
+  )
+}

--- a/apps/admin/app/templates/page.tsx
+++ b/apps/admin/app/templates/page.tsx
@@ -9,10 +9,9 @@ import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { TemplateEditor } from '@/components/template-editor'
-import { EmptyState } from '@/components/ux/empty-state'
 import { useTemplates } from '@/hooks/use-templates'
 import { templates } from '@/lib/mock'
-import { formatChannel, humanTemplateName } from '@/lib/ux/labels'
+import { formatChannel, templateTitle } from '@/lib/ux/labels'
 import type { TemplateDefinition } from '@/types/api'
 
 const fallback: TemplateDefinition[] = templates.map((x) => ({
@@ -37,7 +36,7 @@ export default function TemplatesPage() {
     return data.filter(
       (x) =>
         (channel === 'all' || x.channel === channel) &&
-        `${x.key} ${x.subject} ${x.locale}`.toLowerCase().includes(q.toLowerCase()),
+        `${templateTitle(x)} ${x.key} ${x.locale}`.toLowerCase().includes(q.toLowerCase()),
     )
   }, [result.data, channel, q])
 
@@ -52,7 +51,7 @@ export default function TemplatesPage() {
         <PageHeader
           eyebrow="Content"
           title="Templates"
-          description="Create and manage the messages your notifications and campaigns send."
+          description="Reusable message content for notifications and campaigns."
           action={
             <Button
               onClick={() => {
@@ -67,16 +66,8 @@ export default function TemplatesPage() {
 
         <div className="mb-5 grid gap-3 md:grid-cols-3">
           <Metric icon={FileText} label="Templates" value={String(rows.length)} />
-          <Metric
-            icon={Sparkles}
-            label="Active"
-            value={String(rows.filter((x) => x.isActive !== false).length)}
-          />
-          <Metric
-            icon={SlidersHorizontal}
-            label="Channels"
-            value={String(new Set(rows.map((x) => x.channel)).size)}
-          />
+          <Metric icon={Sparkles} label="Active" value={String(rows.filter((x) => x.isActive !== false).length)} />
+          <Metric icon={SlidersHorizontal} label="Channels" value={String(new Set(rows.map((x) => x.channel)).size)} />
         </div>
 
         <Card className="overflow-hidden">
@@ -98,9 +89,7 @@ export default function TemplatesPage() {
                     type="button"
                     onClick={() => setChannel(x)}
                     className={`rounded-lg px-3 py-2 text-xs font-medium transition ${
-                      channel === x
-                        ? 'bg-background text-foreground shadow-sm'
-                        : 'text-muted-foreground hover:text-foreground'
+                      channel === x ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
                     }`}
                   >
                     {x === 'all' ? 'All' : formatChannel(x)}
@@ -109,57 +98,49 @@ export default function TemplatesPage() {
               </div>
             </div>
 
-            {!rows.length ? (
-              <div className="p-6">
-                <EmptyState
-                  icon={FileText}
-                  title={q ? 'No templates match your search' : 'No templates yet'}
-                  description={
-                    q
-                      ? 'Try a different name or clear the filters.'
-                      : 'Create your first notification template to get started.'
-                  }
-                  actionLabel={q ? undefined : 'Create template'}
-                  onAction={
-                    q
-                      ? undefined
-                      : () => {
-                          setSelected(undefined)
-                          setOpen(true)
-                        }
-                  }
-                />
-              </div>
-            ) : (
-              <div>
-                {rows.map((x, i) => (
-                  <motion.button
-                    key={`${x.key}-${x.channel}-${x.locale}`}
-                    type="button"
-                    onClick={() => edit(x)}
-                    initial={{ opacity: 0, y: 6 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ delay: i * 0.025 }}
-                    className="grid w-full gap-2 border-b px-5 py-4 text-left transition hover:bg-muted/30 md:grid-cols-[1.6fr_.7fr_.7fr_.5fr_auto] md:items-center"
-                  >
-                    <div>
-                      <div className="text-sm font-semibold">{humanTemplateName(x.key, x.subject)}</div>
-                      <div className="mt-1 truncate text-xs text-muted-foreground">{x.body || x.subject}</div>
-                    </div>
-                    <div>
-                      <Badge variant="outline">{formatChannel(x.channel)}</Badge>
-                    </div>
-                    <div className="text-sm text-muted-foreground">{x.locale}</div>
-                    <div>
-                      <Badge variant={x.isActive === false ? 'default' : 'success'}>
-                        {x.isActive === false ? 'Inactive' : 'Active'}
-                      </Badge>
-                    </div>
-                    <div className="text-xs text-muted-foreground">Open →</div>
-                  </motion.button>
-                ))}
-              </div>
-            )}
+            <div className="hidden grid-cols-[1.6fr_.7fr_.7fr_.45fr_.5fr_auto] gap-4 border-b bg-muted/20 px-5 py-3 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground md:grid">
+              <span>Name</span>
+              <span>Channel</span>
+              <span>Language</span>
+              <span>Version</span>
+              <span>Status</span>
+              <span />
+            </div>
+
+            <div>
+              {rows.map((x, i) => (
+                <motion.button
+                  key={`${x.key}-${x.channel}-${x.locale}`}
+                  type="button"
+                  onClick={() => edit(x)}
+                  initial={{ opacity: 0, y: 6 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: i * 0.025 }}
+                  className="grid w-full gap-2 border-b px-5 py-4 text-left transition hover:bg-muted/30 md:grid-cols-[1.6fr_.7fr_.7fr_.45fr_.5fr_auto] md:items-center"
+                >
+                  <div>
+                    <div className="text-sm font-semibold">{templateTitle(x)}</div>
+                    <div className="mt-1 truncate text-xs text-muted-foreground">{x.subject || 'No subject'}</div>
+                  </div>
+                  <div>
+                    <Badge variant="outline">{formatChannel(x.channel)}</Badge>
+                  </div>
+                  <div className="text-sm text-muted-foreground">{x.locale}</div>
+                  <div className="text-sm">v{x.version ?? 1}</div>
+                  <div>
+                    <Badge variant={x.isActive === false ? 'default' : 'success'}>
+                      {x.isActive === false ? 'Inactive' : 'Active'}
+                    </Badge>
+                  </div>
+                  <div className="text-xs text-muted-foreground">Edit</div>
+                </motion.button>
+              ))}
+              {!rows.length && (
+                <div className="p-12 text-center text-sm text-muted-foreground">
+                  No templates match your search. Try another channel or create a new template.
+                </div>
+              )}
+            </div>
           </CardContent>
         </Card>
       </div>
@@ -168,15 +149,7 @@ export default function TemplatesPage() {
   )
 }
 
-function Metric({
-  icon: Icon,
-  label,
-  value,
-}: {
-  icon: React.ComponentType<{ size?: number }>
-  label: string
-  value: string
-}) {
+function Metric({ icon: Icon, label, value }: { icon: React.ComponentType<{ size?: number }>; label: string; value: string }) {
   return (
     <Card>
       <CardContent className="flex items-center gap-3 p-4">

--- a/apps/admin/app/templates/page.tsx
+++ b/apps/admin/app/templates/page.tsx
@@ -1,6 +1,7 @@
 'use client'
+
 import { useMemo, useState } from 'react'
-import { AnimatePresence, motion } from 'framer-motion'
+import { motion } from 'framer-motion'
 import { FileText, Plus, Search, SlidersHorizontal, Sparkles } from 'lucide-react'
 import { PageHeader } from '@/components/page-header'
 import { Card, CardContent } from '@/components/ui/card'
@@ -8,10 +9,185 @@ import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { TemplateEditor } from '@/components/template-editor'
+import { EmptyState } from '@/components/ux/empty-state'
 import { useTemplates } from '@/hooks/use-templates'
 import { templates } from '@/lib/mock'
+import { formatChannel, humanTemplateName } from '@/lib/ux/labels'
 import type { TemplateDefinition } from '@/types/api'
 
-const fallback:TemplateDefinition[]=templates.map(x=>({key:x[0],subject:x[1],channel:x[2],locale:x[3],version:Number(x[4])||1,isActive:x[5]==='Active',body:x[1]}))
-export default function TemplatesPage(){const [channel,setChannel]=useState('all');const [q,setQ]=useState('');const [open,setOpen]=useState(false);const [selected,setSelected]=useState<TemplateDefinition>();const result=useTemplates(channel==='all'?undefined:channel);const rows=useMemo(()=>{const data=result.data?.length?result.data:fallback;return data.filter(x=>(channel==='all'||x.channel===channel)&&`${x.key} ${x.subject} ${x.locale}`.toLowerCase().includes(q.toLowerCase()))},[result.data,channel,q]);const edit=(x:TemplateDefinition)=>{setSelected(x);setOpen(true)};return <div className="grid-bg min-h-full p-5 md:p-8"><div className="mx-auto max-w-[1500px]"><PageHeader eyebrow="Content system" title="Templates" description="Manage localized, versioned content used by every notification and campaign." action={<Button onClick={()=>{setSelected(undefined);setOpen(true)}}><Plus size={16}/>New template</Button>}/><div className="mb-5 grid gap-3 md:grid-cols-3"><Metric icon={FileText} label="Templates" value={String(rows.length)}/><Metric icon={Sparkles} label="Active" value={String(rows.filter(x=>x.isActive!==false).length)}/><Metric icon={SlidersHorizontal} label="Channels" value={String(new Set(rows.map(x=>x.channel)).size)}/></div><Card className="overflow-hidden"><CardContent className="p-0"><div className="flex flex-col gap-3 border-b p-4 lg:flex-row"><div className="relative flex-1"><Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"/><Input className="pl-9" value={q} onChange={e=>setQ(e.target.value)} placeholder="Search key, subject or locale..."/></div><div className="flex gap-1 rounded-xl border bg-muted/30 p-1">{['all','email','sms','push','webhook'].map(x=><button key={x} onClick={()=>setChannel(x)} className={`rounded-lg px-3 py-2 text-xs font-medium transition ${channel===x?'bg-background shadow-sm text-foreground':'text-muted-foreground hover:text-foreground'}`}>{x==='all'?'All':x.toUpperCase()}</button>)}</div></div><div className="hidden grid-cols-[1.4fr_.7fr_.7fr_.45fr_.5fr_auto] gap-4 border-b bg-muted/20 px-5 py-3 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground md:grid"><span>Template</span><span>Channel</span><span>Locale</span><span>Version</span><span>State</span><span/></div><div>{rows.map((x,i)=><motion.button key={`${x.key}-${x.channel}-${x.locale}`} onClick={()=>edit(x)} initial={{opacity:0,y:6}} animate={{opacity:1,y:0}} transition={{delay:i*.025}} className="grid w-full gap-2 border-b px-5 py-4 text-left transition hover:bg-muted/30 md:grid-cols-[1.4fr_.7fr_.7fr_.45fr_.5fr_auto] md:items-center"><div><div className="font-mono text-sm font-semibold">{x.key}</div><div className="mt-1 truncate text-xs text-muted-foreground">{x.subject}</div></div><div><Badge variant="outline">{x.channel}</Badge></div><div className="text-sm text-muted-foreground">{x.locale}</div><div className="text-sm">v{x.version??1}</div><div><Badge variant={x.isActive===false?'default':'success'}>{x.isActive===false?'Inactive':'Active'}</Badge></div><div className="text-xs text-muted-foreground">Edit →</div></motion.button>)}{!rows.length&&<div className="p-12 text-center text-sm text-muted-foreground">No templates match your filters.</div>}</div></CardContent></Card></div><TemplateEditor open={open} onOpenChange={setOpen} initial={selected}/></div>}
-function Metric({icon:Icon,label,value}:{icon:any;label:string;value:string}){return <Card><CardContent className="flex items-center gap-3 p-4"><div className="grid h-9 w-9 place-items-center rounded-xl bg-primary/10 text-primary"><Icon size={17}/></div><div><div className="text-xs text-muted-foreground">{label}</div><div className="text-lg font-semibold">{value}</div></div></CardContent></Card>}
+const fallback: TemplateDefinition[] = templates.map((x) => ({
+  key: x[0],
+  subject: x[1],
+  channel: x[2],
+  locale: x[3],
+  version: Number(x[4]) || 1,
+  isActive: x[5] === 'Active',
+  body: x[1],
+}))
+
+export default function TemplatesPage() {
+  const [channel, setChannel] = useState('all')
+  const [q, setQ] = useState('')
+  const [open, setOpen] = useState(false)
+  const [selected, setSelected] = useState<TemplateDefinition>()
+  const result = useTemplates(channel === 'all' ? undefined : channel)
+
+  const rows = useMemo(() => {
+    const data = result.data?.length ? result.data : fallback
+    return data.filter(
+      (x) =>
+        (channel === 'all' || x.channel === channel) &&
+        `${x.key} ${x.subject} ${x.locale}`.toLowerCase().includes(q.toLowerCase()),
+    )
+  }, [result.data, channel, q])
+
+  const edit = (x: TemplateDefinition) => {
+    setSelected(x)
+    setOpen(true)
+  }
+
+  return (
+    <div className="grid-bg min-h-full p-5 md:p-8">
+      <div className="mx-auto max-w-[1500px]">
+        <PageHeader
+          eyebrow="Content"
+          title="Templates"
+          description="Create and manage the messages your notifications and campaigns send."
+          action={
+            <Button
+              onClick={() => {
+                setSelected(undefined)
+                setOpen(true)
+              }}
+            >
+              <Plus size={16} /> New template
+            </Button>
+          }
+        />
+
+        <div className="mb-5 grid gap-3 md:grid-cols-3">
+          <Metric icon={FileText} label="Templates" value={String(rows.length)} />
+          <Metric
+            icon={Sparkles}
+            label="Active"
+            value={String(rows.filter((x) => x.isActive !== false).length)}
+          />
+          <Metric
+            icon={SlidersHorizontal}
+            label="Channels"
+            value={String(new Set(rows.map((x) => x.channel)).size)}
+          />
+        </div>
+
+        <Card className="overflow-hidden">
+          <CardContent className="p-0">
+            <div className="flex flex-col gap-3 border-b p-4 lg:flex-row">
+              <div className="relative flex-1">
+                <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  className="pl-9"
+                  value={q}
+                  onChange={(e) => setQ(e.target.value)}
+                  placeholder="Search by name or language…"
+                />
+              </div>
+              <div className="flex gap-1 rounded-xl border bg-muted/30 p-1">
+                {['all', 'email', 'sms', 'push', 'webhook'].map((x) => (
+                  <button
+                    key={x}
+                    type="button"
+                    onClick={() => setChannel(x)}
+                    className={`rounded-lg px-3 py-2 text-xs font-medium transition ${
+                      channel === x
+                        ? 'bg-background text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    {x === 'all' ? 'All' : formatChannel(x)}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {!rows.length ? (
+              <div className="p-6">
+                <EmptyState
+                  icon={FileText}
+                  title={q ? 'No templates match your search' : 'No templates yet'}
+                  description={
+                    q
+                      ? 'Try a different name or clear the filters.'
+                      : 'Create your first notification template to get started.'
+                  }
+                  actionLabel={q ? undefined : 'Create template'}
+                  onAction={
+                    q
+                      ? undefined
+                      : () => {
+                          setSelected(undefined)
+                          setOpen(true)
+                        }
+                  }
+                />
+              </div>
+            ) : (
+              <div>
+                {rows.map((x, i) => (
+                  <motion.button
+                    key={`${x.key}-${x.channel}-${x.locale}`}
+                    type="button"
+                    onClick={() => edit(x)}
+                    initial={{ opacity: 0, y: 6 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: i * 0.025 }}
+                    className="grid w-full gap-2 border-b px-5 py-4 text-left transition hover:bg-muted/30 md:grid-cols-[1.6fr_.7fr_.7fr_.5fr_auto] md:items-center"
+                  >
+                    <div>
+                      <div className="text-sm font-semibold">{humanTemplateName(x.key, x.subject)}</div>
+                      <div className="mt-1 truncate text-xs text-muted-foreground">{x.body || x.subject}</div>
+                    </div>
+                    <div>
+                      <Badge variant="outline">{formatChannel(x.channel)}</Badge>
+                    </div>
+                    <div className="text-sm text-muted-foreground">{x.locale}</div>
+                    <div>
+                      <Badge variant={x.isActive === false ? 'default' : 'success'}>
+                        {x.isActive === false ? 'Inactive' : 'Active'}
+                      </Badge>
+                    </div>
+                    <div className="text-xs text-muted-foreground">Open →</div>
+                  </motion.button>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+      <TemplateEditor open={open} onOpenChange={setOpen} initial={selected} />
+    </div>
+  )
+}
+
+function Metric({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: React.ComponentType<{ size?: number }>
+  label: string
+  value: string
+}) {
+  return (
+    <Card>
+      <CardContent className="flex items-center gap-3 p-4">
+        <div className="grid h-9 w-9 place-items-center rounded-xl bg-primary/10 text-primary">
+          <Icon size={17} />
+        </div>
+        <div>
+          <div className="text-xs text-muted-foreground">{label}</div>
+          <div className="text-lg font-semibold">{value}</div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/admin/app/topics/page.tsx
+++ b/apps/admin/app/topics/page.tsx
@@ -1,3 +1,151 @@
 'use client'
-import {useState} from 'react'; import {PageHeader} from '@/components/page-header'; import {Input} from '@/components/ui/input'; import {Select} from '@/components/ui/select'; import {resourcesApi} from '@/lib/api/resources'; import {useTenant} from '@/providers/tenant-provider'; import {OperationPanel,Field} from '@/components/operation-panel';
-export default function Page(){const {tenantId}=useTenant();const [key,setKey]=useState('product-updates');const [name,setName]=useState('Product updates');const [subscriberId,setSubscriberId]=useState('user-123');const [channel,setChannel]=useState('push');const [address,setAddress]=useState('');return <div className="grid-bg min-h-full p-5 md:p-8"><div className="mx-auto max-w-[1100px]"><PageHeader eyebrow="Audience" title="Topics" description="Manage pub/sub topics and channel-specific subscriptions."/><div className="grid gap-5 lg:grid-cols-2"><OperationPanel title="Topic definition" description="POST /api/v1/topics" onSubmit={()=>resourcesApi.topics.save({key,name,tenantId,isActive:true})}><Field label="Key"><Input value={key} onChange={e=>setKey(e.target.value)}/></Field><Field label="Name"><Input value={name} onChange={e=>setName(e.target.value)}/></Field></OperationPanel><OperationPanel title="Subscribe" description="POST /api/v1/topics/{key}/subscribe" onSubmit={()=>resourcesApi.topics.subscribe(key,{subscriberId,channel,address,tenantId})} label="Subscribe"><Field label="Subscriber ID"><Input value={subscriberId} onChange={e=>setSubscriberId(e.target.value)}/></Field><Field label="Channel"><Select value={channel} onChange={e=>setChannel(e.target.value)}><option>push</option><option>email</option><option>sms</option><option>webhook</option></Select></Field><Field label="Address" hint="optional"><Input value={address} onChange={e=>setAddress(e.target.value)}/></Field></OperationPanel><OperationPanel title="Unsubscribe" description="POST /api/v1/topics/{key}/unsubscribe" onSubmit={()=>resourcesApi.topics.unsubscribe(key,subscriberId,tenantId)} label="Unsubscribe"><Field label="Subscriber ID"><Input value={subscriberId} onChange={e=>setSubscriberId(e.target.value)}/></Field></OperationPanel><OperationPanel title="Inspect subscribers" description="GET /api/v1/topics/{key}/subscribers" onSubmit={()=>resourcesApi.topics.subscribers(key,tenantId)} label="Fetch"><Field label="Topic key"><Input value={key} onChange={e=>setKey(e.target.value)}/></Field></OperationPanel></div></div></div>}
+
+import { useState } from 'react'
+import { PageHeader } from '@/components/page-header'
+import { Input } from '@/components/ui/input'
+import { Select } from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { ConfirmDialog } from '@/components/confirm-dialog'
+import { ToastHost } from '@/components/toast-host'
+import { resourcesApi } from '@/lib/api/resources'
+import { useTenant } from '@/providers/tenant-provider'
+import { formatChannel, friendlyError, humanizeKey } from '@/lib/ux/labels'
+
+export default function TopicsPage() {
+  const { tenantId } = useTenant()
+  const [key, setKey] = useState('product-updates')
+  const [name, setName] = useState('Product updates')
+  const [subscriberId, setSubscriberId] = useState('')
+  const [channel, setChannel] = useState('push')
+  const [address, setAddress] = useState('')
+  const [subscribers, setSubscribers] = useState<Array<Record<string, unknown>>>([])
+  const [confirmUnsub, setConfirmUnsub] = useState(false)
+  const [toast, setToast] = useState<{ tone: 'success' | 'error'; title: string; description?: string } | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  async function saveTopic() {
+    setBusy(true)
+    try {
+      await resourcesApi.topics.save({ key, name, tenantId, isActive: true })
+      setToast({ tone: 'success', title: 'Topic saved', description: name })
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not save topic', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function subscribe() {
+    setBusy(true)
+    try {
+      await resourcesApi.topics.subscribe(key, { subscriberId, channel, address: address || undefined, tenantId })
+      setToast({ tone: 'success', title: 'Subscribed', description: subscriberId })
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not subscribe', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function unsubscribe() {
+    setBusy(true)
+    try {
+      await resourcesApi.topics.unsubscribe(key, subscriberId, tenantId)
+      setConfirmUnsub(false)
+      setToast({ tone: 'success', title: 'Unsubscribed' })
+      await loadSubs()
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not unsubscribe', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function loadSubs() {
+    setBusy(true)
+    try {
+      const res = (await resourcesApi.topics.subscribers(key, tenantId)) as Array<Record<string, unknown>>
+      setSubscribers(Array.isArray(res) ? res : [])
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not load subscribers', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="grid-bg min-h-full p-5 md:p-8">
+      <ToastHost toast={toast} onClose={() => setToast(null)} />
+      <div className="mx-auto max-w-[1100px]">
+        <PageHeader
+          eyebrow="Content"
+          title="Topics"
+          description="Topics people can subscribe to — product updates, alerts, and more."
+        />
+        <div className="grid gap-5 lg:grid-cols-2">
+          <Card>
+            <CardContent className="space-y-4 p-6">
+              <h2 className="font-semibold">Topic</h2>
+              <Field label="Name"><Input value={name} onChange={(e) => setName(e.target.value)} /></Field>
+              <Field label="Code" hint="Internal identifier"><Input value={key} onChange={(e) => setKey(e.target.value)} /></Field>
+              <Button disabled={busy || !key} onClick={() => void saveTopic()}>Save topic</Button>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent className="space-y-4 p-6">
+              <h2 className="font-semibold">Subscription</h2>
+              <Field label="Subscriber"><Input value={subscriberId} onChange={(e) => setSubscriberId(e.target.value)} placeholder="User ID" /></Field>
+              <Field label="Channel">
+                <Select value={channel} onChange={(e) => setChannel(e.target.value)} className="w-full">
+                  <option value="push">Push</option>
+                  <option value="email">Email</option>
+                  <option value="sms">SMS</option>
+                </Select>
+              </Field>
+              <Field label="Address" hint="Email or phone when needed"><Input value={address} onChange={(e) => setAddress(e.target.value)} /></Field>
+              <div className="flex flex-wrap gap-2">
+                <Button disabled={busy || !subscriberId} onClick={() => void subscribe()}>Subscribe</Button>
+                <Button disabled={busy || !subscriberId} variant="outline" onClick={() => setConfirmUnsub(true)}>Unsubscribe</Button>
+                <Button disabled={busy} variant="ghost" onClick={() => void loadSubs()}>Show subscribers</Button>
+              </div>
+              <div className="space-y-2">
+                {subscribers.map((s, i) => (
+                  <div key={i} className="flex justify-between rounded-xl border p-3 text-sm">
+                    <span>{String(s.subscriberId ?? s.userId ?? s.id ?? 'Subscriber')}</span>
+                    <Badge variant="outline">{formatChannel(String(s.channel ?? ''))}</Badge>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      <ConfirmDialog
+        open={confirmUnsub}
+        onOpenChange={setConfirmUnsub}
+        title="Unsubscribe this person?"
+        confirmLabel="Yes, unsubscribe"
+        destructive
+        busy={busy}
+        onConfirm={unsubscribe}
+        description={`They will stop receiving “${name || humanizeKey(key)}” on ${formatChannel(channel)}.`}
+      />
+    </div>
+  )
+}
+
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-2 text-sm">
+      <span className="flex gap-2 font-medium">
+        {label}
+        {hint && <span className="text-[10px] font-normal text-muted-foreground">{hint}</span>}
+      </span>
+      {children}
+    </label>
+  )
+}

--- a/apps/admin/app/webhooks/page.tsx
+++ b/apps/admin/app/webhooks/page.tsx
@@ -1,3 +1,93 @@
 'use client'
-import {useState} from 'react'; import {PageHeader} from '@/components/page-header'; import {Input} from '@/components/ui/input'; import {Textarea} from '@/components/ui/textarea'; import {Button} from '@/components/ui/button'; import {resourcesApi} from '@/lib/api/resources'; import {useTenant} from '@/providers/tenant-provider'; import {OperationPanel,Field} from '@/components/operation-panel';
-export default function Page(){const {tenantId}=useTenant();const [url,setUrl]=useState('');const [secret,setSecret]=useState('');const [events,setEvents]=useState('notification.sent\nnotification.failed\nnotification.delivered');return <div className="grid-bg min-h-full p-5 md:p-8"><div className="mx-auto max-w-[1000px]"><PageHeader eyebrow="Integrations" title="Webhooks" description="Register signed delivery event subscriptions for external systems."/><OperationPanel title="Create webhook" description="POST /api/v1/webhooks" onSubmit={()=>resourcesApi.webhooks.create({url,secret,events:events.split(/\n|,/).map(x=>x.trim()).filter(Boolean),tenantId,isActive:true})} label="Create webhook"><Field label="Endpoint URL"><Input value={url} onChange={e=>setUrl(e.target.value)} placeholder="https://api.example.com/hooks/notification"/></Field><Field label="Signing secret"><Input type="password" value={secret} onChange={e=>setSecret(e.target.value)}/></Field><Field label="Events" hint="one per line"><Textarea value={events} onChange={e=>setEvents(e.target.value)} className="min-h-40 font-mono text-xs"/></Field></OperationPanel></div></div>}
+
+import { useState } from 'react'
+import { PageHeader } from '@/components/page-header'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { ToastHost } from '@/components/toast-host'
+import { resourcesApi } from '@/lib/api/resources'
+import { useTenant } from '@/providers/tenant-provider'
+import { friendlyError } from '@/lib/ux/labels'
+
+const EVENT_OPTIONS = [
+  { id: 'notification.sent', label: 'Message accepted' },
+  { id: 'notification.delivered', label: 'Message delivered' },
+  { id: 'notification.failed', label: 'Message failed' },
+  { id: 'notification.opened', label: 'Message opened' },
+]
+
+export default function WebhooksPage() {
+  const { tenantId } = useTenant()
+  const [url, setUrl] = useState('')
+  const [secret, setSecret] = useState('')
+  const [events, setEvents] = useState<string[]>(['notification.sent', 'notification.delivered', 'notification.failed'])
+  const [toast, setToast] = useState<{ tone: 'success' | 'error'; title: string; description?: string } | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  function toggle(id: string) {
+    setEvents((e) => (e.includes(id) ? e.filter((x) => x !== id) : [...e, id]))
+  }
+
+  async function create() {
+    setBusy(true)
+    try {
+      await resourcesApi.webhooks.create({ url, secret: secret || undefined, events, tenantId, isActive: true })
+      setToast({ tone: 'success', title: 'Webhook connected', description: 'Your endpoint will receive the selected events.' })
+      setSecret('')
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not create webhook', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="grid-bg min-h-full p-5 md:p-8">
+      <ToastHost toast={toast} onClose={() => setToast(null)} />
+      <div className="mx-auto max-w-[800px]">
+        <PageHeader
+          eyebrow="Integrations"
+          title="Webhooks"
+          description="Notify your systems when delivery events happen."
+        />
+        <Card>
+          <CardContent className="space-y-5 p-6">
+            <Field label="Your endpoint URL">
+              <Input value={url} onChange={(e) => setUrl(e.target.value)} placeholder="https://api.yourapp.com/hooks/notifications" />
+            </Field>
+            <Field label="Signing secret" hint="Shown only while creating — keep it private">
+              <Input type="password" value={secret} onChange={(e) => setSecret(e.target.value)} autoComplete="new-password" />
+            </Field>
+            <div>
+              <div className="mb-2 text-sm font-medium">Events to send</div>
+              <div className="space-y-2">
+                {EVENT_OPTIONS.map((ev) => (
+                  <label key={ev.id} className="flex cursor-pointer items-center gap-3 rounded-xl border p-3 text-sm">
+                    <input type="checkbox" checked={events.includes(ev.id)} onChange={() => toggle(ev.id)} className="h-4 w-4 accent-primary" />
+                    {ev.label}
+                  </label>
+                ))}
+              </div>
+            </div>
+            <Button disabled={busy || !url || !events.length} onClick={() => void create()}>
+              Connect webhook
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-2 text-sm">
+      <span className="flex gap-2 font-medium">
+        {label}
+        {hint && <span className="text-[10px] font-normal text-muted-foreground">{hint}</span>}
+      </span>
+      {children}
+    </label>
+  )
+}

--- a/apps/admin/app/workflows/page.tsx
+++ b/apps/admin/app/workflows/page.tsx
@@ -1,33 +1,254 @@
 'use client'
+
 import { useMemo, useState } from 'react'
 import { motion, Reorder } from 'framer-motion'
-import { Plus, Trash2, GitBranch, Clock, Send, Save, Play, Eye } from 'lucide-react'
+import { Plus, Trash2, GitBranch, Clock, Send, Save, Play } from 'lucide-react'
 import Link from 'next/link'
 import { PageHeader } from '@/components/page-header'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Select } from '@/components/ui/select'
-import { Textarea } from '@/components/ui/textarea'
 import { Badge } from '@/components/ui/badge'
+import { ToastHost } from '@/components/toast-host'
+import { KeyValueEditor, pairsToRecord, type KeyValuePair } from '@/components/key-value-editor'
 import { resourcesApi } from '@/lib/api/resources'
 import { useTemplates } from '@/hooks/use-templates'
 import { useTenant } from '@/providers/tenant-provider'
+import { formatChannel, friendlyError, humanizeKey, templateTitle } from '@/lib/ux/labels'
 import type { WorkflowDefinition, WorkflowStep } from '@/types/api'
 
-const types = ['notification','delay','condition'] as const
-const icons: Record<string, any> = { notification: Send, delay: Clock, condition: GitBranch }
-export default function WorkflowsPage(){
- const {tenantId}=useTenant(); const templates=useTemplates(); const [key,setKey]=useState('payment-received'); const [active,setActive]=useState(true)
- const [steps,setSteps]=useState<WorkflowStep[]>([{id:'step-1',type:'notification',channel:'push',templateKey:'',next:'step-2'},{id:'step-2',type:'delay',delaySeconds:3600,next:'step-3'},{id:'step-3',type:'condition',conditionExpression:'data.amount > 1000000',nextOnTrue:'',nextOnFalse:''}])
- const [recipient,setRecipient]=useState(''); const [runData,setRunData]=useState('{}'); const [runId,setRunId]=useState('')
- const payload=useMemo<WorkflowDefinition>(()=>({key,tenantId,isActive:active,steps}),[key,tenantId,active,steps])
- const add=(type:string)=>setSteps(s=>[...s,{id:`step-${Date.now()}`,type,channel:type==='notification'?'push':undefined}])
- const update=(id:string,p:Partial<WorkflowStep>)=>setSteps(s=>s.map(x=>x.id===id?{...x,...p}:x)); const remove=(id:string)=>setSteps(s=>s.filter(x=>x.id!==id))
- const start=async()=>{const r:any=await resourcesApi.workflows.start({workflowKey:key,recipient,tenantId,data:JSON.parse(runData)});setRunId(String(r?.id??r?.runId??''))}
- return <div className="grid-bg min-h-full p-5 md:p-8"><div className="mx-auto max-w-[1500px]"><PageHeader eyebrow="Orchestration" title="Workflow Studio" description="Visualize and edit WorkflowDefinition without adding fields outside the OpenAPI schema." action={<Link href="/workflows/runs"><Button variant="outline"><Eye size={15}/>Run inspector</Button></Link>}/>
- <div className="grid gap-5 xl:grid-cols-[1fr_380px]"><Card><CardHeader><div className="flex flex-wrap items-center justify-between gap-3"><CardTitle>Workflow graph</CardTitle><div className="flex gap-2">{types.map(t=><Button key={t} size="sm" variant="outline" onClick={()=>add(t)}><Plus size={13}/>{t}</Button>)}</div></div></CardHeader><CardContent><div className="rounded-3xl border bg-muted/20 p-5"><div className="mb-5 grid gap-3 md:grid-cols-[1fr_auto]"><Input value={key} onChange={e=>setKey(e.target.value)} placeholder="workflow-key"/><Button variant={active?'default':'outline'} onClick={()=>setActive(v=>!v)}>{active?'Active':'Draft'}</Button></div>
- <Reorder.Group axis="y" values={steps} onReorder={setSteps} className="space-y-3">{steps.map((s,i)=>{const Icon=icons[s.type]??GitBranch;return <Reorder.Item key={s.id} value={s} as="div"><motion.div layout className="relative rounded-2xl border bg-card p-4 shadow-sm transition-shadow hover:shadow-md"><div className="flex items-center gap-3"><div className="grid h-10 w-10 place-items-center rounded-xl bg-primary/10 text-primary"><Icon size={17}/></div><div className="flex-1"><div className="font-mono text-xs text-muted-foreground">{s.id}</div><div className="mt-1"><Badge variant="outline">{s.type}</Badge></div></div><Button size="icon" variant="ghost" onClick={()=>remove(s.id)}><Trash2 size={15}/></Button></div><div className="mt-4 grid gap-3 md:grid-cols-2">{s.type==='notification'&&<><Field label="Channel"><Select value={s.channel??''} onChange={e=>update(s.id,{channel:e.target.value})}><option value="">Select channel</option><option>push</option><option>email</option><option>sms</option><option>webhook</option></Select></Field><Field label="Template"><Select value={s.templateKey??''} onChange={e=>update(s.id,{templateKey:e.target.value})}><option value="">Select template</option>{templates.data?.map(t=><option key={`${t.key}-${t.channel}-${t.locale}`} value={t.key}>{t.key} · {t.channel} · {t.locale}</option>)}</Select></Field><Field label="Preferred provider"><Input value={s.preferredProvider??''} onChange={e=>update(s.id,{preferredProvider:e.target.value})}/></Field></>}{s.type==='delay'&&<Field label="Delay seconds"><Input type="number" min="0" value={s.delaySeconds??0} onChange={e=>update(s.id,{delaySeconds:Number(e.target.value)})}/></Field>}{s.type==='condition'&&<Field label="Condition expression"><Textarea value={s.conditionExpression??''} onChange={e=>update(s.id,{conditionExpression:e.target.value})}/></Field>}{s.type!=='condition'&&<Field label="Next"><Input value={s.next??''} onChange={e=>update(s.id,{next:e.target.value})}/></Field>}{s.type==='condition'&&<><Field label="Next on true"><Input value={s.nextOnTrue??''} onChange={e=>update(s.id,{nextOnTrue:e.target.value})}/></Field><Field label="Next on false"><Input value={s.nextOnFalse??''} onChange={e=>update(s.id,{nextOnFalse:e.target.value})}/></Field></>}</div>{s.configJson!==undefined&&<Field label="Config JSON"><Textarea value={s.configJson??''} onChange={e=>update(s.id,{configJson:e.target.value})}/></Field>}{i<steps.length-1&&<div className="absolute -bottom-4 left-1/2 h-7 w-px bg-border"/>}</motion.div></Reorder.Item>})}</Reorder.Group></div></CardContent></Card>
- <div className="space-y-5"><Card><CardHeader><CardTitle>Definition</CardTitle></CardHeader><CardContent><pre className="max-h-96 overflow-auto rounded-2xl bg-muted p-4 text-[10px] leading-5">{JSON.stringify(payload,null,2)}</pre><Button className="mt-4 w-full" onClick={()=>resourcesApi.workflows.save(payload)}><Save size={15}/>Save workflow</Button></CardContent></Card><Card><CardHeader><CardTitle>Start run</CardTitle></CardHeader><CardContent className="space-y-3"><Field label="Recipient"><Input value={recipient} onChange={e=>setRecipient(e.target.value)}/></Field><Field label="Data JSON"><Textarea className="min-h-28 font-mono text-xs" value={runData} onChange={e=>setRunData(e.target.value)}/></Field><Button className="w-full" disabled={!recipient} onClick={start}><Play size={15}/>Start workflow</Button>{runId&&<div className="rounded-xl border bg-muted/40 p-3 text-xs">Run created: <span className="font-mono">{runId}</span><Link className="mt-2 block text-primary" href={`/workflows/runs?runId=${encodeURIComponent(runId)}`}>Open run inspector</Link></div>}</CardContent></Card></div></div></div></div>
+const stepTypes = [
+  { type: 'notification', label: 'Send message', icon: Send },
+  { type: 'delay', label: 'Wait', icon: Clock },
+  { type: 'condition', label: 'Branch', icon: GitBranch },
+] as const
+
+const stepLabel = (t: string) => stepTypes.find((x) => x.type === t)?.label ?? t
+
+export default function WorkflowsPage() {
+  const { tenantId } = useTenant()
+  const templates = useTemplates()
+  const [name, setName] = useState('Payment received')
+  const [key, setKey] = useState('payment-received')
+  const [active, setActive] = useState(true)
+  const [steps, setSteps] = useState<WorkflowStep[]>([
+    { id: 'step-1', type: 'notification', channel: 'push', templateKey: '', next: 'step-2' },
+    { id: 'step-2', type: 'delay', delaySeconds: 3600, next: 'step-3' },
+    { id: 'step-3', type: 'condition', conditionExpression: 'amount > 1000000', nextOnTrue: '', nextOnFalse: '' },
+  ])
+  const [recipient, setRecipient] = useState('')
+  const [runPairs, setRunPairs] = useState<KeyValuePair[]>([{ key: 'amount', value: '' }])
+  const [runId, setRunId] = useState('')
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  const [toast, setToast] = useState<{ tone: 'success' | 'error'; title: string; description?: string } | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const payload = useMemo<WorkflowDefinition>(
+    () => ({ key, tenantId, isActive: active, steps }),
+    [key, tenantId, active, steps],
+  )
+
+  const add = (type: string) =>
+    setSteps((s) => [...s, { id: `step-${Date.now()}`, type, channel: type === 'notification' ? 'push' : undefined }])
+
+  const update = (id: string, p: Partial<WorkflowStep>) => setSteps((s) => s.map((x) => (x.id === id ? { ...x, ...p } : x)))
+  const remove = (id: string) => setSteps((s) => s.filter((x) => x.id !== id))
+
+  async function save() {
+    setBusy(true)
+    try {
+      await resourcesApi.workflows.save(payload)
+      setToast({ tone: 'success', title: 'Workflow saved', description: name || humanizeKey(key) })
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not save workflow', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function start() {
+    setBusy(true)
+    try {
+      const r = (await resourcesApi.workflows.start({
+        workflowKey: key,
+        recipient,
+        tenantId,
+        data: pairsToRecord(runPairs),
+      })) as { id?: string; runId?: string }
+      const id = String(r?.id ?? r?.runId ?? '')
+      setRunId(id)
+      setToast({ tone: 'success', title: 'Workflow started' })
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not start workflow', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="grid-bg min-h-full p-5 md:p-8">
+      <ToastHost toast={toast} onClose={() => setToast(null)} />
+      <div className="mx-auto max-w-[1500px]">
+        <PageHeader
+          eyebrow="Automation"
+          title="Workflows"
+          description="Build multi-step message journeys: send, wait, and branch."
+          action={
+            <Link href="/workflows/runs">
+              <Button variant="outline">View runs</Button>
+            </Link>
+          }
+        />
+
+        <div className="grid gap-5 xl:grid-cols-[1fr_360px]">
+          <Card>
+            <CardHeader>
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <CardTitle>Steps</CardTitle>
+                <div className="flex flex-wrap gap-2">
+                  {stepTypes.map((t) => (
+                    <Button key={t.type} size="sm" variant="outline" onClick={() => add(t.type)}>
+                      <Plus size={13} /> {t.label}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="mb-5 grid gap-3 md:grid-cols-[1fr_1fr_auto]">
+                <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Workflow name" />
+                <Input value={key} onChange={(e) => setKey(e.target.value)} placeholder="Internal code" />
+                <Button variant={active ? 'default' : 'outline'} onClick={() => setActive((v) => !v)}>
+                  {active ? 'Active' : 'Draft'}
+                </Button>
+              </div>
+
+              <Reorder.Group axis="y" values={steps} onReorder={setSteps} className="space-y-3">
+                {steps.map((s, i) => {
+                  const meta = stepTypes.find((x) => x.type === s.type)
+                  const Icon = meta?.icon ?? GitBranch
+                  return (
+                    <Reorder.Item key={s.id} value={s} as="div">
+                      <motion.div layout className="rounded-2xl border bg-card p-4 shadow-sm">
+                        <div className="flex items-center gap-3">
+                          <div className="grid h-10 w-10 place-items-center rounded-xl bg-primary/10 text-primary">
+                            <Icon size={17} />
+                          </div>
+                          <div className="flex-1">
+                            <div className="text-sm font-medium">{stepLabel(s.type)}</div>
+                            <div className="text-xs text-muted-foreground">Step {i + 1}</div>
+                          </div>
+                          <Button size="icon" variant="ghost" onClick={() => remove(s.id)}>
+                            <Trash2 size={15} />
+                          </Button>
+                        </div>
+
+                        <div className="mt-4 grid gap-3 md:grid-cols-2">
+                          {s.type === 'notification' && (
+                            <>
+                              <Field label="Channel">
+                                <Select value={s.channel ?? ''} onChange={(e) => update(s.id, { channel: e.target.value })}>
+                                  <option value="">Choose channel</option>
+                                  <option value="push">Push</option>
+                                  <option value="email">Email</option>
+                                  <option value="sms">SMS</option>
+                                </Select>
+                              </Field>
+                              <Field label="Template">
+                                <Select value={s.templateKey ?? ''} onChange={(e) => update(s.id, { templateKey: e.target.value })}>
+                                  <option value="">Choose template</option>
+                                  {templates.data?.map((t) => (
+                                    <option key={`${t.key}-${t.channel}-${t.locale}`} value={t.key}>
+                                      {templateTitle(t)} · {formatChannel(t.channel)}
+                                    </option>
+                                  ))}
+                                </Select>
+                              </Field>
+                            </>
+                          )}
+                          {s.type === 'delay' && (
+                            <Field label="Wait (minutes)">
+                              <Input
+                                type="number"
+                                min={0}
+                                value={Math.round((s.delaySeconds ?? 0) / 60)}
+                                onChange={(e) => update(s.id, { delaySeconds: Number(e.target.value) * 60 })}
+                              />
+                            </Field>
+                          )}
+                          {s.type === 'condition' && (
+                            <Field label="When" hint="Simple expression, e.g. amount > 1000">
+                              <Input
+                                value={s.conditionExpression ?? ''}
+                                onChange={(e) => update(s.id, { conditionExpression: e.target.value })}
+                                placeholder="amount > 1000000"
+                              />
+                            </Field>
+                          )}
+                          {showAdvanced && s.type !== 'condition' && (
+                            <Field label="Next step id">
+                              <Input value={s.next ?? ''} onChange={(e) => update(s.id, { next: e.target.value })} />
+                            </Field>
+                          )}
+                          {showAdvanced && s.type === 'condition' && (
+                            <>
+                              <Field label="If true → step"><Input value={s.nextOnTrue ?? ''} onChange={(e) => update(s.id, { nextOnTrue: e.target.value })} /></Field>
+                              <Field label="If false → step"><Input value={s.nextOnFalse ?? ''} onChange={(e) => update(s.id, { nextOnFalse: e.target.value })} /></Field>
+                            </>
+                          )}
+                        </div>
+                      </motion.div>
+                    </Reorder.Item>
+                  )
+                })}
+              </Reorder.Group>
+
+              <button type="button" className="mt-4 text-xs text-primary" onClick={() => setShowAdvanced((v) => !v)}>
+                {showAdvanced ? 'Hide step linking' : 'Show step linking (advanced)'}
+              </button>
+
+              <Button className="mt-4" disabled={busy} onClick={() => void save()}>
+                <Save size={15} /> Save workflow
+              </Button>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader><CardTitle>Start for someone</CardTitle></CardHeader>
+            <CardContent className="space-y-3">
+              <Field label="Recipient">
+                <Input value={recipient} onChange={(e) => setRecipient(e.target.value)} placeholder="User ID" />
+              </Field>
+              <Field label="Context values">
+                <KeyValueEditor pairs={runPairs} onChange={setRunPairs} />
+              </Field>
+              <Button className="w-full" disabled={!recipient || busy} onClick={() => void start()}>
+                <Play size={15} /> Start journey
+              </Button>
+              {runId && (
+                <div className="rounded-xl border bg-muted/40 p-3 text-sm">
+                  Journey started.
+                  <Link className="mt-2 block text-primary" href={`/workflows/runs?runId=${encodeURIComponent(runId)}`}>
+                    Open run details
+                  </Link>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
 }
-function Field({label,children}:{label:string;children:React.ReactNode}){return <label className="space-y-1.5 text-xs"><span className="font-medium text-muted-foreground">{label}</span>{children}</label>}
+
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-1.5 text-xs">
+      <span className="font-medium text-muted-foreground">
+        {label}{hint && <span className="ml-1 font-normal">· {hint}</span>}
+      </span>
+      {children}
+    </label>
+  )
+}

--- a/apps/admin/app/workflows/runs/page.tsx
+++ b/apps/admin/app/workflows/runs/page.tsx
@@ -2,18 +2,26 @@
 
 import { Suspense, useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
-import { Activity, Clock3, Search, GitBranch } from 'lucide-react'
+import { Activity, Search, GitBranch } from 'lucide-react'
 import { PageHeader } from '@/components/page-header'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { ConfirmDialog } from '@/components/confirm-dialog'
+import { ToastHost } from '@/components/toast-host'
 import { useWorkflowRun, useWorkflowTimeline } from '@/hooks/use-workflow-run'
+import { resourcesApi } from '@/lib/api/resources'
+import { formatDateTime, formatStatus, friendlyError, statusTone } from '@/lib/ux/labels'
 
 function WorkflowRunsContent() {
   const [input, setInput] = useState('')
   const [runId, setRunId] = useState('')
+  const [confirmCancel, setConfirmCancel] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [toast, setToast] = useState<{ tone: 'success' | 'error'; title: string; description?: string } | null>(null)
   const params = useSearchParams()
+
   useEffect(() => {
     const id = params.get('runId')
     if (id) {
@@ -21,82 +29,96 @@ function WorkflowRunsContent() {
       setRunId(id)
     }
   }, [params])
+
   const run = useWorkflowRun(runId)
   const timeline = useWorkflowTimeline(runId)
-  const runData: any = run.data ?? {}
-  const events: any[] = Array.isArray(timeline.data)
-    ? timeline.data
-    : Array.isArray((timeline.data as any)?.items)
-      ? (timeline.data as any).items
+  const runData = (run.data ?? {}) as Record<string, unknown>
+  const events: Array<Record<string, unknown>> = Array.isArray(timeline.data)
+    ? (timeline.data as Array<Record<string, unknown>>)
+    : Array.isArray((timeline.data as { items?: unknown[] })?.items)
+      ? ((timeline.data as { items: Array<Record<string, unknown>> }).items)
       : []
+
   const status = String(runData.status ?? 'Unknown')
   const terminal = ['completed', 'failed', 'cancelled', 'completedwitherrors'].includes(
-    status.toLowerCase().replace(/\s/g, '')
+    status.toLowerCase().replace(/\s/g, ''),
   )
+
+  async function cancel() {
+    setBusy(true)
+    try {
+      await resourcesApi.workflows.cancel(runId)
+      setConfirmCancel(false)
+      setToast({ tone: 'success', title: 'Run cancelled' })
+      void run.refetch?.()
+    } catch (e) {
+      setToast({ tone: 'error', title: 'Could not cancel', description: friendlyError(e) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
   return (
     <div className="grid-bg min-h-full p-5 md:p-8">
+      <ToastHost toast={toast} onClose={() => setToast(null)} />
       <div className="mx-auto max-w-[1250px]">
         <PageHeader
-          eyebrow="Orchestration / Operations"
-          title="Workflow run inspector"
-          description="Inspect execution through the WorkflowRun and Timeline endpoints exposed by the backend contract."
+          eyebrow="Automation"
+          title="Workflow runs"
+          description="See where a journey is, what already ran, and what is next."
         />
         <Card>
           <CardContent className="p-5">
             <div className="flex gap-2">
-              <Input
-                className="font-mono"
-                value={input}
-                onChange={(e) => setInput(e.target.value)}
-                placeholder="Workflow run UUID"
-              />
+              <Input value={input} onChange={(e) => setInput(e.target.value)} placeholder="Paste a run reference" />
               <Button disabled={!input.trim()} onClick={() => setRunId(input.trim())}>
-                <Search size={16} />
-                Inspect run
+                <Search size={16} /> Look up
               </Button>
             </div>
           </CardContent>
         </Card>
+
         {runId && (
-          <div className="mt-5 grid gap-5 lg:grid-cols-[340px_1fr]">
+          <div className="mt-5 grid gap-5 lg:grid-cols-[320px_1fr]">
             <Card>
               <CardHeader>
-                <CardTitle className="flex items-center justify-between">
-                  Run{' '}
-                  <Badge
-                    variant={
-                      terminal ? (status.toLowerCase() === 'completed' ? 'success' : 'danger') : 'warning'
-                    }
-                  >
-                    {status}
-                  </Badge>
+                <CardTitle className="flex items-center justify-between gap-2">
+                  Status
+                  <Badge variant={statusTone(status)}>{formatStatus(status)}</Badge>
                 </CardTitle>
               </CardHeader>
-              <CardContent className="space-y-5 text-sm">
+              <CardContent className="space-y-4 text-sm">
                 <div>
-                  <div className="text-xs text-muted-foreground">Run ID</div>
-                  <div className="mt-1 break-all font-mono text-xs">{runId}</div>
+                  <div className="text-xs text-muted-foreground">Recipient</div>
+                  <div className="mt-1 font-medium">{String(runData.recipient ?? '—')}</div>
                 </div>
-                <Row icon={Activity} label="Run endpoint" value="GET /api/v1/workflows/runs/{runId}" />
-                <Row icon={Clock3} label="Timeline" value="GET /api/v1/workflows/runs/{runId}/timeline" />
-                <Row icon={Activity} label="Refresh" value={terminal ? 'Stopped' : '2.5s'} />
-                {run.isError && (
-                  <p className="text-destructive">The backend did not return a successful run response.</p>
+                <div>
+                  <div className="text-xs text-muted-foreground">Workflow</div>
+                  <div className="mt-1 font-medium">{String(runData.workflowKey ?? runData.workflow ?? '—')}</div>
+                </div>
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <Activity size={14} />
+                  {terminal ? 'Finished' : 'Updating live'}
+                </div>
+                {!terminal && (
+                  <Button variant="ghost" className="text-destructive" onClick={() => setConfirmCancel(true)}>
+                    Cancel run
+                  </Button>
                 )}
+                {run.isError && <p className="text-destructive">This run could not be loaded.</p>}
               </CardContent>
             </Card>
+
             <Card>
-              <CardHeader>
-                <CardTitle>Execution timeline</CardTitle>
-              </CardHeader>
+              <CardHeader><CardTitle>Timeline</CardTitle></CardHeader>
               <CardContent>
                 {events.length === 0 ? (
                   <div className="rounded-2xl border border-dashed p-10 text-center text-sm text-muted-foreground">
-                    No timeline items returned by the API yet.
+                    No steps recorded yet for this run.
                   </div>
                 ) : (
-                  <div className="relative space-y-3">
-                    {events.map((event: any, i) => (
+                  <div className="space-y-3">
+                    {events.map((event, i) => (
                       <div key={i} className="flex gap-4 rounded-2xl border p-4">
                         <div className="mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-xl bg-primary/10 text-primary">
                           <GitBranch size={15} />
@@ -104,15 +126,18 @@ function WorkflowRunsContent() {
                         <div className="min-w-0 flex-1">
                           <div className="flex flex-wrap items-center justify-between gap-2">
                             <div className="font-medium">
-                              {String(event.stepId ?? event.id ?? event.type ?? `Event ${i + 1}`)}
+                              {String(event.name ?? event.stepType ?? event.type ?? event.stepId ?? `Step ${i + 1}`)}
                             </div>
-                            <span className="text-xs text-muted-foreground">
-                              {String(event.occurredAt ?? event.createdAt ?? '')}
-                            </span>
+                            <Badge variant={statusTone(String(event.status ?? ''))}>
+                              {formatStatus(String(event.status ?? event.state ?? ''))}
+                            </Badge>
                           </div>
-                          <pre className="mt-2 overflow-auto rounded-xl bg-muted p-3 text-[11px]">
-                            {JSON.stringify(event, null, 2)}
-                          </pre>
+                          <div className="mt-1 text-xs text-muted-foreground">
+                            {formatDateTime(String(event.occurredAt ?? event.createdAt ?? ''))}
+                          </div>
+                          {event.message != null && (
+                            <p className="mt-2 text-sm text-muted-foreground">{String(event.message)}</p>
+                          )}
                         </div>
                       </div>
                     ))}
@@ -123,26 +148,25 @@ function WorkflowRunsContent() {
           </div>
         )}
       </div>
+
+      <ConfirmDialog
+        open={confirmCancel}
+        onOpenChange={setConfirmCancel}
+        title="Cancel this run?"
+        confirmLabel="Yes, cancel"
+        destructive
+        busy={busy}
+        onConfirm={cancel}
+        description="Remaining steps will not run. Steps already completed stay as they are."
+      />
     </div>
   )
 }
 
 export default function WorkflowRunsPage() {
   return (
-    <Suspense fallback={<div className="p-8 text-sm text-muted-foreground">Loading run inspector…</div>}>
+    <Suspense fallback={<div className="p-8 text-sm text-muted-foreground">Loading…</div>}>
       <WorkflowRunsContent />
     </Suspense>
-  )
-}
-
-function Row({ icon: Icon, label, value }: { icon: any; label: string; value: string }) {
-  return (
-    <div className="flex items-start gap-3">
-      <Icon size={16} className="mt-0.5 text-muted-foreground" />
-      <div>
-        <div className="text-xs text-muted-foreground">{label}</div>
-        <div className="mt-0.5 font-medium">{value}</div>
-      </div>
-    </div>
   )
 }

--- a/apps/admin/components/app-shell.tsx
+++ b/apps/admin/components/app-shell.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { Sidebar } from '@/components/sidebar'
+import { Topbar } from '@/components/topbar'
+import { RequireAuth } from '@/components/require-auth'
+
+const PUBLIC = ['/login', '/auth/callback', '/auth/accept-invite']
+
+export function AppShell({ children }: { children: React.ReactNode }) {
+  const path = usePathname()
+  const isPublic = PUBLIC.some((p) => path === p || path.startsWith(p + '/'))
+
+  if (isPublic) {
+    return <RequireAuth>{children}</RequireAuth>
+  }
+
+  return (
+    <RequireAuth>
+      <div className="min-h-screen bg-background">
+        <Sidebar />
+        <div className="lg:pl-[270px]">
+          <Topbar />
+          <main className="min-h-[calc(100vh-72px)]">{children}</main>
+        </div>
+      </div>
+    </RequireAuth>
+  )
+}

--- a/apps/admin/components/confirm-dialog.tsx
+++ b/apps/admin/components/confirm-dialog.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { Dialog } from './ui/dialog'
+import { Button } from './ui/button'
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Go back',
+  destructive,
+  busy,
+  onConfirm,
+}: {
+  open: boolean
+  onOpenChange: (v: boolean) => void
+  title: string
+  description: React.ReactNode
+  confirmLabel?: string
+  cancelLabel?: string
+  destructive?: boolean
+  busy?: boolean
+  onConfirm: () => void | Promise<void>
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange} title={title} description={typeof description === 'string' ? description : undefined}>
+      <div className="space-y-5 p-5">
+        {typeof description !== 'string' && <div className="text-sm leading-6 text-muted-foreground">{description}</div>}
+        <div className="flex justify-end gap-2 border-t pt-4">
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+            {cancelLabel}
+          </Button>
+          <Button
+            variant={destructive ? 'destructive' : 'default'}
+            disabled={busy}
+            onClick={() => void onConfirm()}
+          >
+            {busy ? 'Working…' : confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  )
+}

--- a/apps/admin/components/key-value-editor.tsx
+++ b/apps/admin/components/key-value-editor.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { Plus, Trash2 } from 'lucide-react'
+import { Button } from './ui/button'
+import { Input } from './ui/input'
+
+export type KeyValuePair = { key: string; value: string }
+
+/** Human key/value personalization — never a JSON textarea as primary input. */
+export function KeyValueEditor({
+  pairs,
+  onChange,
+  keyPlaceholder = 'Field name',
+  valuePlaceholder = 'Value',
+}: {
+  pairs: KeyValuePair[]
+  onChange: (next: KeyValuePair[]) => void
+  keyPlaceholder?: string
+  valuePlaceholder?: string
+}) {
+  function update(i: number, patch: Partial<KeyValuePair>) {
+    onChange(pairs.map((p, idx) => (idx === i ? { ...p, ...patch } : p)))
+  }
+
+  function remove(i: number) {
+    onChange(pairs.filter((_, idx) => idx !== i))
+  }
+
+  function add() {
+    onChange([...pairs, { key: '', value: '' }])
+  }
+
+  return (
+    <div className="space-y-2">
+      {pairs.length === 0 && (
+        <p className="rounded-xl border border-dashed p-4 text-center text-xs text-muted-foreground">
+          No personalization fields yet. Add fields that your template expects (for example amount or name).
+        </p>
+      )}
+      {pairs.map((p, i) => (
+        <div key={i} className="flex gap-2">
+          <Input
+            value={p.key}
+            onChange={(e) => update(i, { key: e.target.value })}
+            placeholder={keyPlaceholder}
+            className="w-[40%]"
+          />
+          <Input
+            value={p.value}
+            onChange={(e) => update(i, { value: e.target.value })}
+            placeholder={valuePlaceholder}
+            className="flex-1"
+          />
+          <Button type="button" size="icon" variant="ghost" onClick={() => remove(i)} aria-label="Remove field">
+            <Trash2 size={15} />
+          </Button>
+        </div>
+      ))}
+      <Button type="button" variant="outline" size="sm" onClick={add}>
+        <Plus size={14} /> Add field
+      </Button>
+    </div>
+  )
+}
+
+export function pairsToRecord(pairs: KeyValuePair[]): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const p of pairs) {
+    const k = p.key.trim()
+    if (k) out[k] = p.value
+  }
+  return out
+}
+
+export function recordToPairs(data?: Record<string, unknown> | null): KeyValuePair[] {
+  if (!data) return []
+  return Object.entries(data).map(([key, value]) => ({
+    key,
+    value: value == null ? '' : String(value),
+  }))
+}

--- a/apps/admin/components/operation-panel.tsx
+++ b/apps/admin/components/operation-panel.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react'
 import { Loader2, Save } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Textarea } from '@/components/ui/textarea'
 import { ToastHost } from '@/components/toast-host'
 import { ApiError } from '@/lib/api/errors'
 import { friendlyError } from '@/lib/ux/labels'
@@ -15,31 +14,29 @@ export function OperationPanel({
   children,
   onSubmit,
   label = 'Save',
+  successMessage = 'Saved successfully.',
 }: {
   title: string
   description?: string
   children: React.ReactNode
   onSubmit: () => Promise<unknown>
   label?: string
+  successMessage?: string
 }) {
   const [busy, setBusy] = useState(false)
-  const [toast, setToast] = useState<{
-    tone: 'success' | 'error'
-    title: string
-    description?: string
-  } | null>(null)
+  const [toast, setToast] = useState<{ tone: 'success' | 'error'; title: string; description?: string } | null>(null)
 
   async function submit() {
     setBusy(true)
     setToast(null)
     try {
       await onSubmit()
-      setToast({ tone: 'success', title: 'Saved', description: 'Your changes are in effect.' })
+      setToast({ tone: 'success', title: successMessage })
     } catch (e) {
       setToast({
         tone: 'error',
         title: 'Could not save',
-        description: friendlyError(e instanceof ApiError ? e.message : undefined),
+        description: e instanceof ApiError ? friendlyError(e) : friendlyError(e),
       })
     } finally {
       setBusy(false)
@@ -51,15 +48,17 @@ export function OperationPanel({
       <ToastHost toast={toast} onClose={() => setToast(null)} />
       <Card className="overflow-hidden">
         <CardHeader className="border-b bg-muted/20">
-          <CardTitle>{title}</CardTitle>
-          {description && <p className="mt-1 text-xs text-muted-foreground">{description}</p>}
+          <div>
+            <CardTitle>{title}</CardTitle>
+            {description && <p className="mt-1 text-xs text-muted-foreground">{description}</p>}
+          </div>
         </CardHeader>
         <CardContent className="space-y-5 p-6">
           {children}
           <div className="flex justify-end border-t pt-4">
-            <Button onClick={submit} disabled={busy}>
+            <Button onClick={() => void submit()} disabled={busy}>
               {busy ? <Loader2 size={15} className="animate-spin" /> : <Save size={15} />}
-              {busy ? 'Saving…' : label}
+              {busy ? 'Working…' : label}
             </Button>
           </div>
         </CardContent>
@@ -85,22 +84,5 @@ export function Field({
       </span>
       {children}
     </label>
-  )
-}
-
-/** Advanced-only: technical payload editor. Do not use as primary form control. */
-export function JsonArea({ value, onChange }: { value: string; onChange: (v: string) => void }) {
-  return (
-    <div className="space-y-2">
-      <p className="text-[10px] font-medium uppercase tracking-widest text-muted-foreground">
-        Technical details
-      </p>
-      <Textarea
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="min-h-40 font-mono text-xs"
-        spellCheck={false}
-      />
-    </div>
   )
 }

--- a/apps/admin/components/operation-panel.tsx
+++ b/apps/admin/components/operation-panel.tsx
@@ -1,18 +1,106 @@
 'use client'
-import {useState} from 'react'
-import {Loader2, Play, Save, RotateCcw} from 'lucide-react'
-import {Card,CardContent,CardHeader,CardTitle} from '@/components/ui/card'
-import {Button} from '@/components/ui/button'
-import {Input} from '@/components/ui/input'
-import {Textarea} from '@/components/ui/textarea'
-import {Badge} from '@/components/ui/badge'
-import {ToastHost} from '@/components/toast-host'
-import {ApiError} from '@/lib/api/errors'
 
-export function OperationPanel({title,description,children,onSubmit,label='Save'}:{title:string;description?:string;children:React.ReactNode;onSubmit:()=>Promise<unknown>;label?:string}){
- const [busy,setBusy]=useState(false); const [toast,setToast]=useState<any>(null)
- async function submit(){setBusy(true);setToast(null);try{await onSubmit();setToast({tone:'success',title:'Operation completed',description:'The NotificationHub API accepted the request.'})}catch(e){setToast({tone:'error',title:'Operation failed',description:e instanceof ApiError?e.message:'Unable to reach the API.'})}finally{setBusy(false)}}
- return <><ToastHost toast={toast} onClose={()=>setToast(null)}/><Card className="overflow-hidden"><CardHeader className="border-b bg-muted/20"><div className="flex items-center justify-between gap-3"><div><CardTitle>{title}</CardTitle>{description&&<p className="mt-1 text-xs text-muted-foreground">{description}</p>}</div><Badge variant="outline">API</Badge></div></CardHeader><CardContent className="space-y-5 p-6">{children}<div className="flex justify-end border-t pt-4"><Button onClick={submit} disabled={busy}>{busy?<Loader2 size={15} className="animate-spin"/>:<Save size={15}/>} {busy?'Working…':label}</Button></div></CardContent></Card></>
+import { useState } from 'react'
+import { Loader2, Save } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { ToastHost } from '@/components/toast-host'
+import { ApiError } from '@/lib/api/errors'
+import { friendlyError } from '@/lib/ux/labels'
+
+export function OperationPanel({
+  title,
+  description,
+  children,
+  onSubmit,
+  label = 'Save',
+}: {
+  title: string
+  description?: string
+  children: React.ReactNode
+  onSubmit: () => Promise<unknown>
+  label?: string
+}) {
+  const [busy, setBusy] = useState(false)
+  const [toast, setToast] = useState<{
+    tone: 'success' | 'error'
+    title: string
+    description?: string
+  } | null>(null)
+
+  async function submit() {
+    setBusy(true)
+    setToast(null)
+    try {
+      await onSubmit()
+      setToast({ tone: 'success', title: 'Saved', description: 'Your changes are in effect.' })
+    } catch (e) {
+      setToast({
+        tone: 'error',
+        title: 'Could not save',
+        description: friendlyError(e instanceof ApiError ? e.message : undefined),
+      })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <>
+      <ToastHost toast={toast} onClose={() => setToast(null)} />
+      <Card className="overflow-hidden">
+        <CardHeader className="border-b bg-muted/20">
+          <CardTitle>{title}</CardTitle>
+          {description && <p className="mt-1 text-xs text-muted-foreground">{description}</p>}
+        </CardHeader>
+        <CardContent className="space-y-5 p-6">
+          {children}
+          <div className="flex justify-end border-t pt-4">
+            <Button onClick={submit} disabled={busy}>
+              {busy ? <Loader2 size={15} className="animate-spin" /> : <Save size={15} />}
+              {busy ? 'Saving…' : label}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </>
+  )
 }
-export function Field({label,hint,children}:{label:string;hint?:string;children:React.ReactNode}){return <label className="block space-y-2"><span className="flex gap-2 text-sm font-medium">{label}{hint&&<span className="text-[10px] font-normal text-muted-foreground">{hint}</span>}</span>{children}</label>}
-export function JsonArea({value,onChange}:{value:string;onChange:(v:string)=>void}){return <Textarea value={value} onChange={e=>onChange(e.target.value)} className="min-h-40 font-mono text-xs" spellCheck={false}/>} 
+
+export function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string
+  hint?: string
+  children: React.ReactNode
+}) {
+  return (
+    <label className="block space-y-2">
+      <span className="flex gap-2 text-sm font-medium">
+        {label}
+        {hint && <span className="text-[10px] font-normal text-muted-foreground">{hint}</span>}
+      </span>
+      {children}
+    </label>
+  )
+}
+
+/** Advanced-only: technical payload editor. Do not use as primary form control. */
+export function JsonArea({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div className="space-y-2">
+      <p className="text-[10px] font-medium uppercase tracking-widest text-muted-foreground">
+        Technical details
+      </p>
+      <Textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="min-h-40 font-mono text-xs"
+        spellCheck={false}
+      />
+    </div>
+  )
+}

--- a/apps/admin/components/require-auth.tsx
+++ b/apps/admin/components/require-auth.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePathname, useRouter } from 'next/navigation'
+import { useAuth } from '@/providers/auth-provider'
+import { getAccessToken } from '@/lib/auth/session'
+
+const PUBLIC = ['/login', '/auth/callback', '/auth/accept-invite']
+
+export function RequireAuth({ children }: { children: React.ReactNode }) {
+  const { isLoading, isAuthenticated, login } = useAuth()
+  const path = usePathname()
+  const router = useRouter()
+  const isPublic = PUBLIC.some((p) => path === p || path.startsWith(p + '/'))
+
+  useEffect(() => {
+    if (isPublic || isLoading) return
+    if (!getAccessToken() || !isAuthenticated) {
+      login(path)
+    }
+  }, [isPublic, isLoading, isAuthenticated, login, path])
+
+  if (isPublic) return <>{children}</>
+  if (isLoading) {
+    return (
+      <div className="grid min-h-[40vh] place-items-center text-sm text-muted-foreground">
+        Loading session…
+      </div>
+    )
+  }
+  if (!isAuthenticated) return null
+  return <>{children}</>
+}
+
+export function RequirePermission({
+  permission,
+  children,
+  fallback,
+}: {
+  permission: string | string[]
+  children: React.ReactNode
+  fallback?: React.ReactNode
+}) {
+  const { can } = useAuth()
+  if (!can(permission)) {
+    return (
+      fallback ?? (
+        <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-6 text-sm text-destructive">
+          You do not have permission to view this page.
+        </div>
+      )
+    )
+  }
+  return <>{children}</>
+}

--- a/apps/admin/components/section-card.tsx
+++ b/apps/admin/components/section-card.tsx
@@ -1,2 +1,29 @@
-import {Card,CardHeader,CardTitle,CardContent} from './ui/card'; import {ReactNode} from 'react'
-export function SectionCard({title,subtitle,action,children}:{title:string,subtitle?:string,action?:ReactNode,children:ReactNode}){return <Card><CardHeader className="flex-row items-center justify-between"><div><CardTitle>{title}</CardTitle>{subtitle&&<p className="mt-1 text-xs text-muted-foreground">{subtitle}</p>}</div>{action}</CardHeader><CardContent>{children}</CardContent></Card>}
+import { Card, CardHeader, CardTitle, CardContent } from './ui/card'
+import { ReactNode } from 'react'
+
+export function SectionCard({
+  title,
+  subtitle,
+  action,
+  children,
+  className,
+}: {
+  title: string
+  subtitle?: string
+  action?: ReactNode
+  children: ReactNode
+  className?: string
+}) {
+  return (
+    <Card className={className}>
+      <CardHeader className="flex-row items-center justify-between">
+        <div>
+          <CardTitle>{title}</CardTitle>
+          {subtitle && <p className="mt-1 text-xs text-muted-foreground">{subtitle}</p>}
+        </div>
+        {action}
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  )
+}

--- a/apps/admin/components/sidebar.tsx
+++ b/apps/admin/components/sidebar.tsx
@@ -1,4 +1,111 @@
 'use client'
-import Link from 'next/link'; import {usePathname} from 'next/navigation'; import {LayoutDashboard,Send,Workflow,FileText,Users,Smartphone,SlidersHorizontal,ShieldCheck,Radio,Webhook,BarChart3,PlugZap,Layers3,BellRing,ChevronRight} from 'lucide-react'; import {cn} from '@/lib/utils'
-const groups=[{label:'Core',items:[['/dashboard','Overview',LayoutDashboard],['/notifications','Notifications',BellRing],['/campaigns','Campaigns',Send],['/workflows','Workflows',Workflow],['/broadcasts','Broadcast',Send]]},{label:'Audience',items:[['/segments','Segments',Users],['/devices','Devices',Smartphone],['/preferences','Preferences',SlidersHorizontal],['/consents','Consents',ShieldCheck],['/topics','Topics',Radio]]},{label:'Content & Ops',items:[['/templates','Templates',FileText],['/webhooks','Webhooks',Webhook],['/engagement','Engagement',BarChart3],['/plugins','Plugins',PlugZap]]}]
-export function Sidebar(){const path=usePathname();return <aside className="fixed inset-y-0 left-0 z-40 hidden w-[270px] border-r bg-card lg:block"><div className="flex h-full flex-col"><div className="flex h-[72px] items-center gap-3 border-b px-6"><div className="grid h-9 w-9 place-items-center rounded-xl bg-primary text-primary-foreground shadow-lg shadow-primary/25"><Layers3 size={18}/></div><div><div className="font-bold tracking-tight">NotificationHub</div><div className="text-[10px] uppercase tracking-[.2em] text-muted-foreground">Control Plane</div></div></div><div className="flex-1 overflow-y-auto p-4">{groups.map(g=><div key={g.label} className="mb-6"><div className="mb-2 px-3 text-[10px] font-semibold uppercase tracking-[.18em] text-muted-foreground">{g.label}</div>{g.items.map(([href,label,Icon]:any)=><Link key={href} href={href} className={cn('group mb-1 flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm text-muted-foreground transition-all hover:bg-muted hover:text-foreground',path===href||path.startsWith(href+'/')?'bg-primary/10 font-medium text-primary shadow-sm':'')}><Icon size={17}/><span className="flex-1">{label}</span><ChevronRight size={14} className="opacity-0 transition group-hover:opacity-50"/></Link>)}</div>)}</div><div className="border-t p-4"><div className="rounded-2xl bg-gradient-to-br from-primary/10 via-primary/5 to-transparent p-4"><div className="mb-2 flex items-center gap-2"><span className="h-2 w-2 animate-pulse rounded-full bg-emerald-500"/><span className="text-xs font-medium">All systems operational</span></div><p className="text-xs leading-5 text-muted-foreground">Messaging infrastructure is healthy.</p></div></div></div></aside>}
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import {
+  LayoutDashboard, Send, Workflow, FileText, Users, Smartphone,SlidersHorizontal,
+  ShieldCheck, Radio, Webhook, BarChart3, PlugZap, Layers3, BellRing, ChevronRight,
+  Building2, UserCog,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useAuth } from '@/providers/auth-provider'
+import { Perm } from '@/lib/auth/permissions'
+
+const groups = [
+  {
+    label: 'Core',
+    items: [
+      ['/dashboard', 'Overview', LayoutDashboard, null],
+      ['/notifications', 'Notifications', BellRing, null],
+      ['/campaigns', 'Campaigns', Send, null],
+      ['/workflows', 'Workflows', Workflow, null],
+      ['/broadcasts', 'Broadcast', Send, null],
+    ] as const,
+  },
+  {
+    label: 'Audience',
+    items: [
+      ['/segments', 'Segments', Users, null],
+      ['/devices', 'Devices', Smartphone, null],
+      ['/preferences', 'Preferences',SlidersHorizontal, null],
+      ['/consents', 'Consents', ShieldCheck, null],
+      ['/topics', 'Topics', Radio, null],
+    ] as const,
+  },
+  {
+    label: 'Content & Ops',
+    items: [
+      ['/templates', 'Templates', FileText, null],
+      ['/webhooks', 'Webhooks', Webhook, null],
+      ['/engagement', 'Engagement', BarChart3, null],
+      ['/plugins', 'Plugins', PlugZap, null],
+    ] as const,
+  },
+  {
+    label: 'Organization',
+    items: [
+      ['/organization/members', 'Members', UserCog, Perm.MemberRead],
+      ['/organization/settings', 'Settings', Building2, Perm.OrganizationRead],
+      ['/account/sessions', 'Sessions', ShieldCheck, null],
+    ] as const,
+  },
+]
+
+export function Sidebar() {
+  const path = usePathname()
+  const { can, isAuthenticated } = useAuth()
+
+  return (
+    <aside className="fixed inset-y-0 left-0 z-40 hidden w-[270px] border-r bg-card lg:block">
+      <div className="flex h-full flex-col">
+        <div className="flex h-[72px] items-center gap-3 border-b px-6">
+          <div className="grid h-9 w-9 place-items-center rounded-xl bg-primary text-primary-foreground shadow-lg shadow-primary/25">
+            <Layers3 size={18} />
+          </div>
+          <div>
+            <div className="font-bold tracking-tight">NotificationHub</div>
+            <div className="text-[10px] uppercase tracking-[.2em] text-muted-foreground">Control Plane</div>
+          </div>
+        </div>
+        <div className="flex-1 overflow-y-auto p-4">
+          {groups.map((g) => {
+            const items = g.items.filter(([, , , perm]) => !perm || !isAuthenticated || can(perm))
+            if (!items.length) return null
+            return (
+              <div key={g.label} className="mb-6">
+                <div className="mb-2 px-3 text-[10px] font-semibold uppercase tracking-[.18em] text-muted-foreground">
+                  {g.label}
+                </div>
+                {items.map(([href, label, Icon]) => (
+                  <Link
+                    key={href}
+                    href={href}
+                    className={cn(
+                      'group mb-1 flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm text-muted-foreground transition-all hover:bg-muted hover:text-foreground',
+                      path === href || path.startsWith(href + '/')
+                        ? 'bg-primary/10 font-medium text-primary shadow-sm'
+                        : '',
+                    )}
+                  >
+                    <Icon size={17} />
+                    <span className="flex-1">{label}</span>
+                    <ChevronRight size={14} className="opacity-0 transition group-hover:opacity-50" />
+                  </Link>
+                ))}
+              </div>
+            )
+          })}
+        </div>
+        <div className="border-t p-4">
+          <div className="rounded-2xl bg-gradient-to-br from-primary/10 via-primary/5 to-transparent p-4">
+            <div className="mb-2 flex items-center gap-2">
+              <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-500" />
+              <span className="text-xs font-medium">All systems operational</span>
+            </div>
+            <p className="text-xs leading-5 text-muted-foreground">Messaging infrastructure is healthy.</p>
+          </div>
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/apps/admin/components/sidebar.tsx
+++ b/apps/admin/components/sidebar.tsx
@@ -3,9 +3,25 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import {
-  LayoutDashboard, Send, Workflow, FileText, Users, Smartphone,SlidersHorizontal,
-  ShieldCheck, Radio, Webhook, BarChart3, PlugZap, Layers3, BellRing, ChevronRight,
-  Building2, UserCog,
+  LayoutDashboard,
+  Send,
+  Workflow,
+  FileText,
+  Users,
+  Smartphone,
+  SlidersHorizontal,
+  ShieldCheck,
+  Radio,
+  Webhook,
+  BarChart3,
+  PlugZap,
+  Layers3,
+  BellRing,
+  ChevronRight,
+  Building2,
+  UserCog,
+  Megaphone,
+  Activity,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useAuth } from '@/providers/auth-provider'
@@ -13,31 +29,45 @@ import { Perm } from '@/lib/auth/permissions'
 
 const groups = [
   {
-    label: 'Core',
+    label: 'Overview',
+    items: [['/dashboard', 'Overview', LayoutDashboard, null]] as const,
+  },
+  {
+    label: 'Send',
     items: [
-      ['/dashboard', 'Overview', LayoutDashboard, null],
-      ['/notifications', 'Notifications', BellRing, null],
-      ['/campaigns', 'Campaigns', Send, null],
-      ['/workflows', 'Workflows', Workflow, null],
+      ['/notifications', 'Send notification', BellRing, null],
       ['/broadcasts', 'Broadcast', Send, null],
+      ['/campaigns', 'Campaigns', Megaphone, null],
     ] as const,
+  },
+  {
+    label: 'Content',
+    items: [
+      ['/templates', 'Templates', FileText, null],
+      ['/topics', 'Topics', Radio, null],
+      ['/segments', 'Segments', Users, null],
+    ] as const,
+  },
+  {
+    label: 'Automation',
+    items: [['/workflows', 'Workflows', Workflow, null]] as const,
   },
   {
     label: 'Audience',
     items: [
-      ['/segments', 'Segments', Users, null],
       ['/devices', 'Devices', Smartphone, null],
       ['/preferences', 'Preferences',SlidersHorizontal, null],
       ['/consents', 'Consents', ShieldCheck, null],
-      ['/topics', 'Topics', Radio, null],
     ] as const,
   },
   {
-    label: 'Content & Ops',
+    label: 'Analytics',
+    items: [['/engagement', 'Engagement', BarChart3, null]] as const,
+  },
+  {
+    label: 'Integrations',
     items: [
-      ['/templates', 'Templates', FileText, null],
       ['/webhooks', 'Webhooks', Webhook, null],
-      ['/engagement', 'Engagement', BarChart3, null],
       ['/plugins', 'Plugins', PlugZap, null],
     ] as const,
   },
@@ -46,7 +76,7 @@ const groups = [
     items: [
       ['/organization/members', 'Members', UserCog, Perm.MemberRead],
       ['/organization/settings', 'Settings', Building2, Perm.OrganizationRead],
-      ['/account/sessions', 'Sessions', ShieldCheck, null],
+      ['/account/sessions', 'Sessions', Activity, null],
     ] as const,
   },
 ]
@@ -64,7 +94,7 @@ export function Sidebar() {
           </div>
           <div>
             <div className="font-bold tracking-tight">NotificationHub</div>
-            <div className="text-[10px] uppercase tracking-[.2em] text-muted-foreground">Control Plane</div>
+            <div className="text-[10px] uppercase tracking-[.2em] text-muted-foreground">Operations</div>
           </div>
         </div>
         <div className="flex-1 overflow-y-auto p-4">
@@ -100,9 +130,11 @@ export function Sidebar() {
           <div className="rounded-2xl bg-gradient-to-br from-primary/10 via-primary/5 to-transparent p-4">
             <div className="mb-2 flex items-center gap-2">
               <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-500" />
-              <span className="text-xs font-medium">All systems operational</span>
+              <span className="text-xs font-medium">Systems operational</span>
             </div>
-            <p className="text-xs leading-5 text-muted-foreground">Messaging infrastructure is healthy.</p>
+            <p className="text-xs leading-5 text-muted-foreground">
+              Messaging infrastructure is healthy.
+            </p>
           </div>
         </div>
       </div>

--- a/apps/admin/components/sidebar.tsx
+++ b/apps/admin/components/sidebar.tsx
@@ -36,8 +36,8 @@ const groups = [
     label: 'Send',
     items: [
       ['/notifications', 'Send notification', BellRing, null],
-      ['/broadcasts', 'Broadcast', Send, null],
-      ['/campaigns', 'Campaigns', Megaphone, null],
+      ['/broadcasts', 'Broadcast', Megaphone, null],
+      ['/campaigns', 'Campaigns', Send, null],
     ] as const,
   },
   {
@@ -56,7 +56,7 @@ const groups = [
     label: 'Audience',
     items: [
       ['/devices', 'Devices', Smartphone, null],
-      ['/preferences', 'Preferences',SlidersHorizontal, null],
+      ['/preferences', 'Preferences', SlidersHorizontal, null],
       ['/consents', 'Consents', ShieldCheck, null],
     ] as const,
   },
@@ -72,11 +72,12 @@ const groups = [
     ] as const,
   },
   {
-    label: 'Organization',
+    label: 'Operations',
     items: [
+      ['/notifications/status', 'Delivery status', Activity, null],
       ['/organization/members', 'Members', UserCog, Perm.MemberRead],
-      ['/organization/settings', 'Settings', Building2, Perm.OrganizationRead],
-      ['/account/sessions', 'Sessions', Activity, null],
+      ['/organization/settings', 'Organization', Building2, Perm.OrganizationRead],
+      ['/account/sessions', 'Sessions', ShieldCheck, null],
     ] as const,
   },
 ]
@@ -130,11 +131,9 @@ export function Sidebar() {
           <div className="rounded-2xl bg-gradient-to-br from-primary/10 via-primary/5 to-transparent p-4">
             <div className="mb-2 flex items-center gap-2">
               <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-500" />
-              <span className="text-xs font-medium">Systems operational</span>
+              <span className="text-xs font-medium">Systems healthy</span>
             </div>
-            <p className="text-xs leading-5 text-muted-foreground">
-              Messaging infrastructure is healthy.
-            </p>
+            <p className="text-xs leading-5 text-muted-foreground">Messaging infrastructure is operating normally.</p>
           </div>
         </div>
       </div>

--- a/apps/admin/components/topbar.tsx
+++ b/apps/admin/components/topbar.tsx
@@ -1,7 +1,84 @@
 'use client'
-import { Bell, Command, Menu, Moon, Sun, Building2 } from 'lucide-react'
+
+import { Bell, Command, Menu, Moon, Sun, Building2, LogOut } from 'lucide-react'
 import { useState } from 'react'
+import Link from 'next/link'
 import { Button } from './ui/button'
 import { useTenant } from '@/providers/tenant-provider'
+import { useAuth } from '@/providers/auth-provider'
 
-export function Topbar(){const [dark,setDark]=useState(false);const {tenantId,setTenantId}=useTenant();const toggle=()=>{document.documentElement.classList.toggle('dark');setDark(!dark)};return <header className="sticky top-0 z-30 flex h-[72px] items-center gap-4 border-b glass px-5 lg:px-8"><Button variant="ghost" size="icon" className="lg:hidden"><Menu size={20}/></Button><div className="hidden items-center gap-2 rounded-xl border bg-background/70 px-3 py-2 text-xs md:flex"><Building2 size={15} className="text-primary"/><select value={tenantId??'default'} onChange={e=>setTenantId(e.target.value)} className="bg-transparent font-medium outline-none"><option value="default">Default tenant</option><option value="acme">Acme</option><option value="payments">Payments</option><option value="sandbox">Sandbox</option></select></div><div className="ml-auto flex items-center gap-2"><div className="hidden max-w-sm items-center gap-2 rounded-xl border bg-background/70 px-3 py-2 lg:flex"><Command size={14} className="text-muted-foreground"/><span className="text-xs text-muted-foreground">Search anything</span><kbd className="ml-8 rounded border px-1.5 py-0.5 text-[10px] text-muted-foreground">⌘K</kbd></div><Button variant="ghost" size="icon" onClick={toggle}>{dark?<Sun size={18}/>:<Moon size={18}/>}</Button><Button variant="ghost" size="icon" className="relative"><Bell size={18}/><span className="absolute right-2 top-2 h-1.5 w-1.5 rounded-full bg-primary"/></Button><div className="ml-2 flex items-center gap-3 border-l pl-4"><div className="hidden text-right sm:block"><div className="text-sm font-medium">Admin</div><div className="text-[11px] text-muted-foreground">Platform Owner</div></div><div className="grid h-9 w-9 place-items-center rounded-xl bg-gradient-to-br from-primary to-violet-400 text-xs font-bold text-white">AN</div></div></div></header>}
+export function Topbar() {
+  const [dark, setDark] = useState(false)
+  const { tenantId, setTenantId } = useTenant()
+  const { me, organizations, logout, isAuthenticated } = useAuth()
+
+  const toggle = () => {
+    document.documentElement.classList.toggle('dark')
+    setDark(!dark)
+  }
+
+  const initials = (me?.user.displayName || me?.user.email || 'AN')
+    .split(/[\s@]/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((s) => s[0]?.toUpperCase())
+    .join('') || 'AN'
+
+  return (
+    <header className="sticky top-0 z-30 flex h-[72px] items-center gap-4 border-b glass px-5 lg:px-8">
+      <Button variant="ghost" size="icon" className="lg:hidden">
+        <Menu size={20} />
+      </Button>
+      <div className="hidden items-center gap-2 rounded-xl border bg-background/70 px-3 py-2 text-xs md:flex">
+        <Building2 size={15} className="text-primary" />
+        <select
+          value={tenantId ?? ''}
+          onChange={(e) => setTenantId(e.target.value)}
+          className="max-w-[200px] bg-transparent font-medium outline-none"
+          disabled={!organizations.length}
+        >
+          {!organizations.length && <option value="">No organizations</option>}
+          {organizations.map((o) => (
+            <option key={o.organizationId} value={o.organizationId}>
+              {o.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="ml-auto flex items-center gap-2">
+        <div className="hidden max-w-sm items-center gap-2 rounded-xl border bg-background/70 px-3 py-2 lg:flex">
+          <Command size={14} className="text-muted-foreground" />
+          <span className="text-xs text-muted-foreground">Search anything</span>
+          <kbd className="ml-8 rounded border px-1.5 py-0.5 text-[10px] text-muted-foreground">⌘K</kbd>
+        </div>
+        <Button variant="ghost" size="icon" onClick={toggle}>
+          {dark ? <Sun size={18} /> : <Moon size={18} />}
+        </Button>
+        <Button variant="ghost" size="icon" className="relative">
+          <Bell size={18} />
+          <span className="absolute right-2 top-2 h-1.5 w-1.5 rounded-full bg-primary" />
+        </Button>
+        <div className="ml-2 flex items-center gap-3 border-l pl-4">
+          <div className="hidden text-right sm:block">
+            <div className="text-sm font-medium">{me?.user.displayName || me?.user.email || 'Guest'}</div>
+            <div className="text-[11px] text-muted-foreground">
+              {me?.roles?.[0] || (isAuthenticated ? 'Member' : 'Signed out')}
+            </div>
+          </div>
+          <Link
+            href="/account/sessions"
+            className="grid h-9 w-9 place-items-center rounded-xl bg-gradient-to-br from-primary to-violet-400 text-xs font-bold text-white"
+            title="Sessions"
+          >
+            {initials}
+          </Link>
+          {isAuthenticated && (
+            <Button variant="ghost" size="icon" title="Logout" onClick={() => void logout()}>
+              <LogOut size={16} />
+            </Button>
+          )}
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/apps/admin/components/ux/confirm-dialog.tsx
+++ b/apps/admin/components/ux/confirm-dialog.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { Dialog } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  destructive,
+  busy,
+  onConfirm,
+}: {
+  open: boolean
+  onOpenChange: (v: boolean) => void
+  title: string
+  description: string
+  confirmLabel?: string
+  destructive?: boolean
+  busy?: boolean
+  onConfirm: () => void | Promise<void>
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange} title={title} description={description}>
+      <div className="flex justify-end gap-2 border-t p-5">
+        <Button variant="outline" onClick={() => onOpenChange(false)} disabled={busy}>
+          Go back
+        </Button>
+        <Button
+          variant={destructive ? 'destructive' : 'default'}
+          disabled={busy}
+          onClick={() => void onConfirm()}
+        >
+          {confirmLabel}
+        </Button>
+      </div>
+    </Dialog>
+  )
+}

--- a/apps/admin/components/ux/empty-state.tsx
+++ b/apps/admin/components/ux/empty-state.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  actionLabel,
+  onAction,
+}: {
+  icon?: React.ComponentType<{ size?: number }>
+  title: string
+  description: string
+  actionLabel?: string
+  onAction?: () => void
+}) {
+  return (
+    <div className="rounded-2xl border border-dashed p-12 text-center">
+      {Icon && (
+        <div className="mx-auto grid h-12 w-12 place-items-center rounded-2xl bg-primary/10 text-primary">
+          <Icon size={22} />
+        </div>
+      )}
+      <h3 className="mt-4 font-semibold">{title}</h3>
+      <p className="mx-auto mt-2 max-w-md text-sm leading-6 text-muted-foreground">{description}</p>
+      {actionLabel && onAction && (
+        <Button className="mt-5" onClick={onAction}>
+          {actionLabel}
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/apps/admin/components/ux/personalization-fields.tsx
+++ b/apps/admin/components/ux/personalization-fields.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { Plus, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+export type KvPair = { key: string; value: string }
+
+export function pairsToRecord(pairs: KvPair[]): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const p of pairs) {
+    const k = p.key.trim()
+    if (k) out[k] = p.value
+  }
+  return out
+}
+
+export function recordToPairs(data?: Record<string, unknown> | null): KvPair[] {
+  if (!data || !Object.keys(data).length) return [{ key: '', value: '' }]
+  return Object.entries(data).map(([key, value]) => ({ key, value: String(value ?? '') }))
+}
+
+/** Key/value personalization — never a JSON textarea for ordinary operators. */
+export function PersonalizationFields({
+  pairs,
+  onChange,
+  hint = 'Values that fill placeholders in the template (for example amount or name).',
+}: {
+  pairs: KvPair[]
+  onChange: (next: KvPair[]) => void
+  hint?: string
+}) {
+  function update(i: number, patch: Partial<KvPair>) {
+    onChange(pairs.map((p, idx) => (idx === i ? { ...p, ...patch } : p)))
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-muted-foreground">{hint}</p>
+      {pairs.map((p, i) => (
+        <div key={i} className="flex gap-2">
+          <Input
+            placeholder="Field name"
+            value={p.key}
+            onChange={(e) => update(i, { key: e.target.value })}
+            className="flex-1"
+          />
+          <Input
+            placeholder="Value"
+            value={p.value}
+            onChange={(e) => update(i, { value: e.target.value })}
+            className="flex-[1.4]"
+          />
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            disabled={pairs.length <= 1}
+            onClick={() => onChange(pairs.filter((_, idx) => idx !== i))}
+          >
+            <Trash2 size={14} />
+          </Button>
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => onChange([...pairs, { key: '', value: '' }])}
+      >
+        <Plus size={14} /> Add field
+      </Button>
+    </div>
+  )
+}

--- a/apps/admin/components/ux/status-pill.tsx
+++ b/apps/admin/components/ux/status-pill.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { Badge } from '@/components/ui/badge'
+import { formatStatus, statusTone } from '@/lib/ux/labels'
+
+export function StatusPill({ status }: { status?: string | null }) {
+  return <Badge variant={statusTone(status)}>{formatStatus(status)}</Badge>
+}

--- a/apps/admin/lib/api/client.ts
+++ b/apps/admin/lib/api/client.ts
@@ -34,14 +34,20 @@ export async function request<T>(path: string, options: ApiRequestOptions = {}):
 
   const response = await fetch(apiUrl(path), {
     ...options,
-    body: options.body === undefined ? undefined : options.body instanceof FormData ? options.body : JSON.stringify(options.body),
+    body:
+      options.body === undefined
+        ? undefined
+        : options.body instanceof FormData
+          ? options.body
+          : JSON.stringify(options.body),
     headers,
   })
 
   const payload = await parseResponse(response)
 
   if (!response.ok) {
-    const details = typeof payload === 'object' && payload !== null ? payload as ProblemDetails : undefined
+    const details =
+      typeof payload === 'object' && payload !== null ? (payload as ProblemDetails) : undefined
     throw new ApiError(
       details?.detail || details?.title || `Request failed with status ${response.status}`,
       response.status,
@@ -59,6 +65,8 @@ export const api = {
     request<T>(path, { ...options, method: 'POST', body }),
   put: <T>(path: string, body?: unknown, options?: Omit<ApiRequestOptions, 'method' | 'body'>) =>
     request<T>(path, { ...options, method: 'PUT', body }),
+  patch: <T>(path: string, body?: unknown, options?: Omit<ApiRequestOptions, 'method' | 'body'>) =>
+    request<T>(path, { ...options, method: 'PATCH', body }),
   delete: <T>(path: string, options?: Omit<ApiRequestOptions, 'method' | 'body'>) =>
     request<T>(path, { ...options, method: 'DELETE' }),
 }

--- a/apps/admin/lib/api/identity.ts
+++ b/apps/admin/lib/api/identity.ts
@@ -1,0 +1,80 @@
+import { api } from './client'
+
+export interface AuthMe {
+  user: { id: string; email: string; displayName?: string | null }
+  tenant: { id: string; name: string } | null
+  membershipId?: string | null
+  roles: string[]
+  permissions: string[]
+}
+
+export interface OrgMembership {
+  membershipId: string
+  organizationId: string
+  name: string
+  organizationStatus: string
+  membershipStatus: string
+  roles: string[]
+}
+
+export interface MemberRow {
+  membershipId: string
+  userId: string
+  email: string
+  displayName?: string | null
+  status: string
+  roles: string[]
+}
+
+export interface OrganizationDto {
+  id: string
+  name: string
+  slug?: string | null
+  type: string
+  status: string
+}
+
+export interface SessionRow {
+  id: string
+  organizationId?: string | null
+  clientId?: string | null
+  ip?: string | null
+  userAgent?: string | null
+  createdAt: string
+  lastSeenAt: string
+  expiresAt: string
+  isActive: boolean
+}
+
+export const identityApi = {
+  me: () => api.get<AuthMe>('/api/v1/auth/me'),
+  organizations: () => api.get<OrgMembership[]>('/api/v1/auth/organizations'),
+  switchOrganization: (organizationId: string) =>
+    api.post<{ organizationId: string; membershipId: string; roles: string[]; permissions: string[] }>(
+      '/api/v1/auth/organizations/switch',
+      { organizationId },
+    ),
+  logout: () => api.post<void>('/api/v1/auth/logout'),
+  invite: (body: { email: string; roleName?: string; organizationId?: string }) =>
+    api.post<{ id: string }>('/api/v1/auth/invitations', body),
+  acceptInvite: (token: string) => api.post<void>('/api/v1/auth/invitations/accept', { token }),
+  sessions: () => api.get<SessionRow[]>('/api/v1/auth/sessions'),
+  revokeSession: (id: string) => api.delete<void>(`/api/v1/auth/sessions/${id}`),
+  revokeAllSessions: () => api.post<void>('/api/v1/auth/sessions/revoke-all'),
+  getOrganization: (id: string) => api.get<OrganizationDto>(`/api/v1/organizations/${id}`),
+  updateOrganization: (id: string, body: { name?: string; status?: string }) =>
+    api.request ? (api as any).patch?.(`/api/v1/organizations/${id}`, body) :
+    requestPatch<OrganizationDto>(`/api/v1/organizations/${id}`, body),
+  listMembers: (orgId: string) => api.get<MemberRow[]>(`/api/v1/organizations/${orgId}/members`),
+  assignRole: (orgId: string, membershipId: string, roleName: string) =>
+    api.post<void>(`/api/v1/organizations/${orgId}/members/${membershipId}/roles`, { roleName }),
+  removeRole: (orgId: string, membershipId: string, roleName: string) =>
+    api.delete<void>(`/api/v1/organizations/${orgId}/members/${membershipId}/roles/${encodeURIComponent(roleName)}`),
+  setMemberStatus: (orgId: string, membershipId: string, status: string) =>
+    api.post<void>(`/api/v1/organizations/${orgId}/members/${membershipId}/status`, { status }),
+}
+
+async function requestPatch<T>(path: string, body: unknown): Promise<T> {
+  const { request } = await import('./client')
+  return request<T>(path, { method: 'PATCH', body })
+}

--- a/apps/admin/lib/api/identity.ts
+++ b/apps/admin/lib/api/identity.ts
@@ -63,18 +63,14 @@ export const identityApi = {
   revokeAllSessions: () => api.post<void>('/api/v1/auth/sessions/revoke-all'),
   getOrganization: (id: string) => api.get<OrganizationDto>(`/api/v1/organizations/${id}`),
   updateOrganization: (id: string, body: { name?: string; status?: string }) =>
-    api.request ? (api as any).patch?.(`/api/v1/organizations/${id}`, body) :
-    requestPatch<OrganizationDto>(`/api/v1/organizations/${id}`, body),
+    api.patch<OrganizationDto>(`/api/v1/organizations/${id}`, body),
   listMembers: (orgId: string) => api.get<MemberRow[]>(`/api/v1/organizations/${orgId}/members`),
   assignRole: (orgId: string, membershipId: string, roleName: string) =>
     api.post<void>(`/api/v1/organizations/${orgId}/members/${membershipId}/roles`, { roleName }),
   removeRole: (orgId: string, membershipId: string, roleName: string) =>
-    api.delete<void>(`/api/v1/organizations/${orgId}/members/${membershipId}/roles/${encodeURIComponent(roleName)}`),
+    api.delete<void>(
+      `/api/v1/organizations/${orgId}/members/${membershipId}/roles/${encodeURIComponent(roleName)}`,
+    ),
   setMemberStatus: (orgId: string, membershipId: string, status: string) =>
     api.post<void>(`/api/v1/organizations/${orgId}/members/${membershipId}/status`, { status }),
-}
-
-async function requestPatch<T>(path: string, body: unknown): Promise<T> {
-  const { request } = await import('./client')
-  return request<T>(path, { method: 'PATCH', body })
 }

--- a/apps/admin/lib/auth/oidc.ts
+++ b/apps/admin/lib/auth/oidc.ts
@@ -1,0 +1,104 @@
+/**
+ * OIDC Auth Code + PKCE client (SPA).
+ * Tokens in localStorage — documented risk; prefer BFF in production hardening.
+ */
+import { setPkce, setSession, consumePkce, clearSession, getRefreshToken } from './session'
+
+const authority = () => (process.env.NEXT_PUBLIC_IDENTITY_AUTHORITY ?? '').replace(/\/$/, '')
+const clientId = () => process.env.NEXT_PUBLIC_OIDC_CLIENT_ID ?? 'admin-ui'
+const redirectUri = () => process.env.NEXT_PUBLIC_OIDC_REDIRECT_URI ?? (typeof window !== 'undefined' ? `${window.location.origin}/auth/callback` : '')
+const scopes = () => process.env.NEXT_PUBLIC_OIDC_SCOPES ?? 'openid profile email notificationhub.admin offline_access'
+
+function randomString(len = 64) {
+  const arr = new Uint8Array(len)
+  crypto.getRandomValues(arr)
+  return Array.from(arr, (b) => ('0' + b.toString(16)).slice(-2)).join('')
+}
+
+async function sha256Base64Url(input: string) {
+  const data = new TextEncoder().encode(input)
+  const hash = await crypto.subtle.digest('SHA-256', data)
+  const bytes = new Uint8Array(hash)
+  let str = ''
+  bytes.forEach((b) => { str += String.fromCharCode(b) })
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+export async function beginLogin(returnTo?: string) {
+  const verifier = randomString(64)
+  const challenge = await sha256Base64Url(verifier)
+  const state = randomString(24)
+  if (returnTo) sessionStorage.setItem('notificationhub.returnTo', returnTo)
+  setPkce(verifier, state)
+
+  const url = new URL(`${authority()}/connect/authorize`)
+  url.searchParams.set('client_id', clientId())
+  url.searchParams.set('redirect_uri', redirectUri())
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('scope', scopes())
+  url.searchParams.set('state', state)
+  url.searchParams.set('code_challenge', challenge)
+  url.searchParams.set('code_challenge_method', 'S256')
+  window.location.href = url.toString()
+}
+
+export async function handleCallback(search: string) {
+  const params = new URLSearchParams(search)
+  const code = params.get('code')
+  const state = params.get('state')
+  const err = params.get('error')
+  if (err) throw new Error(params.get('error_description') || err)
+  if (!code) throw new Error('missing_code')
+
+  const { verifier, state: expected } = consumePkce()
+  if (!verifier || !expected || expected !== state) throw new Error('invalid_state')
+
+  const body = new URLSearchParams()
+  body.set('grant_type', 'authorization_code')
+  body.set('client_id', clientId())
+  body.set('code', code)
+  body.set('redirect_uri', redirectUri())
+  body.set('code_verifier', verifier)
+
+  const res = await fetch(`${authority()}/connect/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  })
+  if (!res.ok) throw new Error(`token_exchange_${res.status}`)
+  const json = await res.json() as {
+    access_token: string
+    refresh_token?: string
+    expires_in?: number
+  }
+  setSession({
+    accessToken: json.access_token,
+    refreshToken: json.refresh_token,
+  })
+  return json
+}
+
+export async function refreshAccessToken(): Promise<string | undefined> {
+  const refresh = getRefreshToken()
+  if (!refresh) return undefined
+  const body = new URLSearchParams()
+  body.set('grant_type', 'refresh_token')
+  body.set('client_id', clientId())
+  body.set('refresh_token', refresh)
+  const res = await fetch(`${authority()}/connect/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  })
+  if (!res.ok) {
+    clearSession()
+    return undefined
+  }
+  const json = await res.json() as { access_token: string; refresh_token?: string }
+  setSession({ accessToken: json.access_token, refreshToken: json.refresh_token ?? refresh })
+  return json.access_token
+}
+
+export function logoutLocal() {
+  clearSession()
+}

--- a/apps/admin/lib/auth/permissions.ts
+++ b/apps/admin/lib/auth/permissions.ts
@@ -1,0 +1,20 @@
+export const Perm = {
+  OrganizationRead: 'organization.read',
+  OrganizationUpdate: 'organization.update',
+  MemberRead: 'member.read',
+  MemberInvite: 'member.invite',
+  MemberRoleAssign: 'member.role.assign',
+  MemberSuspend: 'member.suspend',
+  AuditRead: 'audit.read',
+} as const
+
+export function hasPermission(permissions: string[] | undefined, required: string | string[]) {
+  if (!permissions?.length) return false
+  const need = Array.isArray(required) ? required : [required]
+  return need.every((p) => permissions.includes(p))
+}
+
+export function hasAnyPermission(permissions: string[] | undefined, required: string[]) {
+  if (!permissions?.length) return false
+  return required.some((p) => permissions.includes(p))
+}

--- a/apps/admin/lib/auth/session.ts
+++ b/apps/admin/lib/auth/session.ts
@@ -1,9 +1,17 @@
 const ACCESS_TOKEN_KEY = 'notificationhub.accessToken'
+const REFRESH_TOKEN_KEY = 'notificationhub.refreshToken'
 const TENANT_ID_KEY = 'notificationhub.tenantId'
+const PKCE_VERIFIER_KEY = 'notificationhub.pkceVerifier'
+const OIDC_STATE_KEY = 'notificationhub.oidcState'
 
 export function getAccessToken(): string | undefined {
   if (typeof window === 'undefined') return undefined
   return window.localStorage.getItem(ACCESS_TOKEN_KEY) ?? undefined
+}
+
+export function getRefreshToken(): string | undefined {
+  if (typeof window === 'undefined') return undefined
+  return window.localStorage.getItem(REFRESH_TOKEN_KEY) ?? undefined
 }
 
 export function getTenantId(): string | undefined {
@@ -11,14 +19,37 @@ export function getTenantId(): string | undefined {
   return window.localStorage.getItem(TENANT_ID_KEY) ?? undefined
 }
 
-export function setSession(input: { accessToken?: string; tenantId?: string }) {
+export function setSession(input: {
+  accessToken?: string
+  refreshToken?: string
+  tenantId?: string
+}) {
   if (typeof window === 'undefined') return
   if (input.accessToken) window.localStorage.setItem(ACCESS_TOKEN_KEY, input.accessToken)
+  if (input.refreshToken) window.localStorage.setItem(REFRESH_TOKEN_KEY, input.refreshToken)
   if (input.tenantId) window.localStorage.setItem(TENANT_ID_KEY, input.tenantId)
 }
 
 export function clearSession() {
   if (typeof window === 'undefined') return
   window.localStorage.removeItem(ACCESS_TOKEN_KEY)
+  window.localStorage.removeItem(REFRESH_TOKEN_KEY)
   window.localStorage.removeItem(TENANT_ID_KEY)
+  window.localStorage.removeItem(PKCE_VERIFIER_KEY)
+  window.localStorage.removeItem(OIDC_STATE_KEY)
+}
+
+export function setPkce(verifier: string, state: string) {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(PKCE_VERIFIER_KEY, verifier)
+  window.localStorage.setItem(OIDC_STATE_KEY, state)
+}
+
+export function consumePkce(): { verifier?: string; state?: string } {
+  if (typeof window === 'undefined') return {}
+  const verifier = window.localStorage.getItem(PKCE_VERIFIER_KEY) ?? undefined
+  const state = window.localStorage.getItem(OIDC_STATE_KEY) ?? undefined
+  window.localStorage.removeItem(PKCE_VERIFIER_KEY)
+  window.localStorage.removeItem(OIDC_STATE_KEY)
+  return { verifier, state }
 }

--- a/apps/admin/lib/ux/labels.ts
+++ b/apps/admin/lib/ux/labels.ts
@@ -1,26 +1,26 @@
-/** Presentation-layer labels — never leak DTO / enum / route names to operators. */
+/** Presentation-layer labels. Never leak DTO/enum/route names to operators. */
 
 export const channelLabel: Record<string, string> = {
   push: 'Push',
   sms: 'SMS',
   email: 'Email',
   webhook: 'Webhook',
-  inapp: 'In-app',
   chat: 'Chat',
+  inapp: 'In-app',
 }
 
-export function formatChannel(channel?: string | null) {
-  if (!channel) return '—'
-  return channelLabel[channel.toLowerCase()] ?? channel
+export function formatChannel(value?: string | null) {
+  if (!value) return '—'
+  return channelLabel[value.toLowerCase()] ?? value
 }
 
-export function formatStatus(status?: string | null) {
-  if (!status) return 'Unknown'
+export function formatStatus(value?: string | null) {
+  if (!value) return 'Unknown'
   const map: Record<string, string> = {
     delivered: 'Delivered',
     pending: 'Pending',
     queued: 'Queued',
-    processing: 'Processing',
+    processing: 'Sending',
     failed: 'Failed',
     cancelled: 'Cancelled',
     canceled: 'Cancelled',
@@ -32,59 +32,70 @@ export function formatStatus(status?: string | null) {
     inactive: 'Inactive',
     success: 'Succeeded',
   }
-  return map[status.toLowerCase()] ?? status.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase())
+  return map[value.toLowerCase()] ?? value.replace(/[_-]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
-export type StatusTone = 'success' | 'warning' | 'danger' | 'default' | 'info'
-
-export function statusTone(status?: string | null): StatusTone {
-  if (!status) return 'default'
-  const s = status.toLowerCase()
-  if (['delivered', 'completed', 'active', 'success', 'succeeded', 'granted'].includes(s)) return 'success'
-  if (['pending', 'queued', 'processing', 'running', 'scheduled', 'draft'].includes(s)) return 'warning'
-  if (['failed', 'cancelled', 'canceled', 'inactive', 'revoked', 'denied'].includes(s)) return 'danger'
+export function statusTone(value?: string | null): 'success' | 'warning' | 'danger' | 'default' | 'outline' {
+  const v = (value ?? '').toLowerCase()
+  if (['delivered', 'completed', 'active', 'success', 'succeeded'].includes(v)) return 'success'
+  if (['pending', 'queued', 'processing', 'running', 'scheduled', 'draft'].includes(v)) return 'warning'
+  if (['failed', 'cancelled', 'canceled', 'inactive', 'error'].includes(v)) return 'danger'
   return 'default'
 }
 
-export function formatRelative(iso?: string | null) {
-  if (!iso) return '—'
-  const d = new Date(iso)
+export function formatDateTime(value?: string | Date | null) {
+  if (!value) return '—'
+  const d = typeof value === 'string' ? new Date(value) : value
+  if (Number.isNaN(d.getTime())) return '—'
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(d)
+}
+
+export function formatRelative(value?: string | Date | null) {
+  if (!value) return '—'
+  const d = typeof value === 'string' ? new Date(value) : value
   if (Number.isNaN(d.getTime())) return '—'
   const diff = Date.now() - d.getTime()
-  const mins = Math.round(diff / 60000)
-  if (Math.abs(mins) < 1) return 'Just now'
-  if (Math.abs(mins) < 60) return mins > 0 ? `${mins} min ago` : `in ${-mins} min`
-  const hrs = Math.round(mins / 60)
-  if (Math.abs(hrs) < 24) return hrs > 0 ? `${hrs}h ago` : `in ${-hrs}h`
-  return d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+  const sec = Math.round(diff / 1000)
+  if (sec < 60) return 'Just now'
+  const min = Math.round(sec / 60)
+  if (min < 60) return `${min}m ago`
+  const hr = Math.round(min / 60)
+  if (hr < 24) return `${hr}h ago`
+  const day = Math.round(hr / 24)
+  if (day < 7) return `${day}d ago`
+  return formatDateTime(d)
 }
 
-export function formatDateTime(iso?: string | null) {
-  if (!iso) return '—'
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return '—'
-  return d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+export function templateTitle(t: { key?: string; subject?: string | null; body?: string | null }) {
+  return t.subject?.trim() || t.body?.slice(0, 48) || humanizeKey(t.key) || 'Untitled template'
 }
 
-export function humanTemplateName(key?: string | null, subject?: string | null) {
-  if (subject?.trim()) return subject.trim()
-  if (!key) return 'Untitled template'
+export function humanizeKey(key?: string | null) {
+  if (!key) return '—'
   return key
-    .replace(/[._-]+/g, ' ')
+    .replace(/[_.-]+/g, ' ')
     .replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
-export function maskId(id?: string | null, keep = 6) {
-  if (!id) return '—'
-  if (id.length <= keep + 2) return id
-  return `…${id.slice(-keep)}`
+export function friendlyError(error: unknown): string {
+  if (!error) return 'Something went wrong. Please try again.'
+  if (typeof error === 'string') return error
+  const msg = (error as { message?: string }).message ?? ''
+  if (/network|fetch|reach/i.test(msg)) return 'Could not reach the server. Check your connection and try again.'
+  if (/401|unauthor/i.test(msg)) return 'Your session expired. Please sign in again.'
+  if (/403|forbidden/i.test(msg)) return 'You do not have permission to do this.'
+  if (/404|not found/i.test(msg)) return 'That item could not be found. It may have been removed.'
+  if (/valid/i.test(msg)) return msg
+  if (msg.length > 0 && msg.length < 160 && !/exception|stack|http/i.test(msg)) return msg
+  return 'The operation could not be completed. Please try again or contact support.'
 }
 
-export function friendlyError(message?: string) {
-  if (!message) return 'Something went wrong. Please try again.'
-  if (/timeout|network|fetch/i.test(message)) return 'Could not reach the server. Check your connection and try again.'
-  if (/unauthorized|401/i.test(message)) return 'Your session expired. Please sign in again.'
-  if (/forbidden|403/i.test(message)) return 'You do not have permission to do this.'
-  if (/not found|404/i.test(message)) return 'This item was not found or is no longer available.'
-  return message
+export const priorityLabel: Record<string, string> = {
+  low: 'Low',
+  normal: 'Normal',
+  high: 'High',
+  critical: 'Urgent',
 }

--- a/apps/admin/lib/ux/labels.ts
+++ b/apps/admin/lib/ux/labels.ts
@@ -1,0 +1,90 @@
+/** Presentation-layer labels — never leak DTO / enum / route names to operators. */
+
+export const channelLabel: Record<string, string> = {
+  push: 'Push',
+  sms: 'SMS',
+  email: 'Email',
+  webhook: 'Webhook',
+  inapp: 'In-app',
+  chat: 'Chat',
+}
+
+export function formatChannel(channel?: string | null) {
+  if (!channel) return '—'
+  return channelLabel[channel.toLowerCase()] ?? channel
+}
+
+export function formatStatus(status?: string | null) {
+  if (!status) return 'Unknown'
+  const map: Record<string, string> = {
+    delivered: 'Delivered',
+    pending: 'Pending',
+    queued: 'Queued',
+    processing: 'Processing',
+    failed: 'Failed',
+    cancelled: 'Cancelled',
+    canceled: 'Cancelled',
+    completed: 'Completed',
+    running: 'Running',
+    scheduled: 'Scheduled',
+    draft: 'Draft',
+    active: 'Active',
+    inactive: 'Inactive',
+    success: 'Succeeded',
+  }
+  return map[status.toLowerCase()] ?? status.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase())
+}
+
+export type StatusTone = 'success' | 'warning' | 'danger' | 'default' | 'info'
+
+export function statusTone(status?: string | null): StatusTone {
+  if (!status) return 'default'
+  const s = status.toLowerCase()
+  if (['delivered', 'completed', 'active', 'success', 'succeeded', 'granted'].includes(s)) return 'success'
+  if (['pending', 'queued', 'processing', 'running', 'scheduled', 'draft'].includes(s)) return 'warning'
+  if (['failed', 'cancelled', 'canceled', 'inactive', 'revoked', 'denied'].includes(s)) return 'danger'
+  return 'default'
+}
+
+export function formatRelative(iso?: string | null) {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '—'
+  const diff = Date.now() - d.getTime()
+  const mins = Math.round(diff / 60000)
+  if (Math.abs(mins) < 1) return 'Just now'
+  if (Math.abs(mins) < 60) return mins > 0 ? `${mins} min ago` : `in ${-mins} min`
+  const hrs = Math.round(mins / 60)
+  if (Math.abs(hrs) < 24) return hrs > 0 ? `${hrs}h ago` : `in ${-hrs}h`
+  return d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+export function formatDateTime(iso?: string | null) {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+export function humanTemplateName(key?: string | null, subject?: string | null) {
+  if (subject?.trim()) return subject.trim()
+  if (!key) return 'Untitled template'
+  return key
+    .replace(/[._-]+/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+export function maskId(id?: string | null, keep = 6) {
+  if (!id) return '—'
+  if (id.length <= keep + 2) return id
+  return `…${id.slice(-keep)}`
+}
+
+export function friendlyError(message?: string) {
+  if (!message) return 'Something went wrong. Please try again.'
+  if (/timeout|network|fetch/i.test(message)) return 'Could not reach the server. Check your connection and try again.'
+  if (/unauthorized|401/i.test(message)) return 'Your session expired. Please sign in again.'
+  if (/forbidden|403/i.test(message)) return 'You do not have permission to do this.'
+  if (/not found|404/i.test(message)) return 'This item was not found or is no longer available.'
+  return message
+}

--- a/apps/admin/providers/app-providers.tsx
+++ b/apps/admin/providers/app-providers.tsx
@@ -2,7 +2,14 @@
 
 import { QueryProvider } from './query-provider'
 import { TenantProvider } from './tenant-provider'
+import { AuthProvider } from './auth-provider'
 
 export function AppProviders({ children }: { children: React.ReactNode }) {
-  return <QueryProvider><TenantProvider>{children}</TenantProvider></QueryProvider>
+  return (
+    <QueryProvider>
+      <AuthProvider>
+        <TenantProvider>{children}</TenantProvider>
+      </AuthProvider>
+    </QueryProvider>
+  )
 }

--- a/apps/admin/providers/auth-provider.tsx
+++ b/apps/admin/providers/auth-provider.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { identityApi, type AuthMe, type OrgMembership } from '@/lib/api/identity'
+import { getAccessToken, setSession, clearSession } from '@/lib/auth/session'
+import { beginLogin, logoutLocal, refreshAccessToken } from '@/lib/auth/oidc'
+import { hasPermission } from '@/lib/auth/permissions'
+
+interface AuthContextValue {
+  me?: AuthMe
+  organizations: OrgMembership[]
+  isLoading: boolean
+  isAuthenticated: boolean
+  can: (permission: string | string[]) => boolean
+  login: (returnTo?: string) => void
+  logout: () => Promise<void>
+  switchOrganization: (organizationId: string) => Promise<void>
+  refreshMe: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null)
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [tokenReady, setTokenReady] = useState(false)
+  const queryClient = useQueryClient()
+
+  useEffect(() => {
+    void (async () => {
+      if (!getAccessToken()) {
+        await refreshAccessToken()
+      }
+      setTokenReady(true)
+    })()
+  }, [])
+
+  const meQuery = useQuery({
+    queryKey: ['auth', 'me'],
+    queryFn: () => identityApi.me(),
+    enabled: tokenReady && !!getAccessToken(),
+    retry: false,
+  })
+
+  const orgsQuery = useQuery({
+    queryKey: ['auth', 'organizations'],
+    queryFn: () => identityApi.organizations(),
+    enabled: tokenReady && !!getAccessToken(),
+    retry: false,
+  })
+
+  const login = useCallback((returnTo?: string) => {
+    void beginLogin(returnTo)
+  }, [])
+
+  const logout = useCallback(async () => {
+    try {
+      if (getAccessToken()) await identityApi.logout()
+    } catch {
+      /* ignore */
+    }
+    logoutLocal()
+    queryClient.clear()
+    window.location.href = '/login'
+  }, [queryClient])
+
+  const switchOrganization = useCallback(async (organizationId: string) => {
+    await identityApi.switchOrganization(organizationId)
+    setSession({ tenantId: organizationId })
+    // Client must re-request token with tenant_id from Identity host when available.
+    await queryClient.invalidateQueries({ queryKey: ['auth'] })
+    await queryClient.invalidateQueries()
+  }, [queryClient])
+
+  const refreshMe = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: ['auth'] })
+  }, [queryClient])
+
+  const value = useMemo<AuthContextValue>(() => ({
+    me: meQuery.data,
+    organizations: orgsQuery.data ?? [],
+    isLoading: !tokenReady || meQuery.isLoading,
+    isAuthenticated: !!getAccessToken() && !!meQuery.data,
+    can: (p) => hasPermission(meQuery.data?.permissions, p),
+    login,
+    logout,
+    switchOrganization,
+    refreshMe,
+  }), [meQuery.data, meQuery.isLoading, orgsQuery.data, tokenReady, login, logout, switchOrganization, refreshMe])
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used inside AuthProvider')
+  return ctx
+}

--- a/apps/admin/providers/tenant-provider.tsx
+++ b/apps/admin/providers/tenant-provider.tsx
@@ -1,9 +1,36 @@
 'use client'
-import { createContext, useContext, useMemo, useState } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
-import { getTenantId } from '@/lib/auth/session'
 
-interface TenantContextValue { tenantId?: string; setTenantId:(value:string)=>void }
-const TenantContext=createContext<TenantContextValue|null>(null)
-export function TenantProvider({children}:{children:React.ReactNode}){const [tenantId,setTenantIdState]=useState<string|undefined>(()=>getTenantId());const queryClient=useQueryClient();const value=useMemo(()=>({tenantId,setTenantId(value:string){setTenantIdState(value);if(typeof window!=='undefined')window.localStorage.setItem('notificationhub.tenantId',value);void queryClient.invalidateQueries()} }),[tenantId,queryClient]);return <TenantContext.Provider value={value}>{children}</TenantContext.Provider>}
-export function useTenant(){const value=useContext(TenantContext);if(!value)throw new Error('useTenant must be used inside TenantProvider');return value}
+import { createContext, useContext, useMemo } from 'react'
+import { useAuth } from './auth-provider'
+import { getTenantId, setSession } from '@/lib/auth/session'
+
+interface TenantContextValue {
+  tenantId?: string
+  setTenantId: (value: string) => void
+}
+
+const TenantContext = createContext<TenantContextValue | null>(null)
+
+export function TenantProvider({ children }: { children: React.ReactNode }) {
+  const { switchOrganization, me } = useAuth()
+  const tenantId = me?.tenant?.id ?? getTenantId()
+
+  const value = useMemo(
+    () => ({
+      tenantId,
+      setTenantId(value: string) {
+        setSession({ tenantId: value })
+        void switchOrganization(value)
+      },
+    }),
+    [tenantId, switchOrganization],
+  )
+
+  return <TenantContext.Provider value={value}>{children}</TenantContext.Provider>
+}
+
+export function useTenant() {
+  const value = useContext(TenantContext)
+  if (!value) throw new Error('useTenant must be used inside TenantProvider')
+  return value
+}

--- a/docs/ADR-019-Multi-Tenant-Identity-RBAC-ABAC.md
+++ b/docs/ADR-019-Multi-Tenant-Identity-RBAC-ABAC.md
@@ -1,0 +1,325 @@
+# ADR-019: Multi-Tenant Identity, Authentication, RBAC & ABAC (B2B IaaS)
+
+## Status
+
+Proposed
+
+## Date
+
+2026-08-30
+
+## Context
+
+NotificationHub is sold as **IaaS / B2B SaaS** to companies (organizations).
+
+Each customer organization must:
+
+- Own its own data boundary (tenant isolation)
+- Manage its own users (invite, roles, suspend, revoke)
+- Authenticate humans via OIDC (Admin Panel)
+- Authorize fine-grained actions (RBAC + ABAC)
+- Be ready for future **Pay-As-You-Go** entitlements and **BNPL** domain features
+
+Today the platform has:
+
+- **API Key authentication** for machine/service clients (send notification, campaigns, …)
+- Simple roles on API keys (`Admin` / `Sender` / `Reader`)
+- Optional `TenantId` on domain entities and request context
+- Placeholder `OidcOptions` (not wired)
+- Admin UI (`apps/admin`) with localStorage token stubs only
+
+**API Key must remain unchanged.** It is the machine-to-machine credential for the notification API.
+Human admin identity is a separate concern.
+
+### Actors
+
+| Actor | Auth mechanism | Purpose |
+|-------|----------------|---------|
+| Machine / Integration | API Key (`X-Api-Key`) | Send notifications, campaigns, webhooks, … |
+| Human Admin (customer) | OIDC + JWT (IdentityServer) | Manage org, users, templates, campaigns, billing later |
+| Platform operator | OIDC + Platform roles | Cross-tenant support / compliance |
+| Internal services | Client Credentials | Service-to-service |
+
+### Goals
+
+1. First-class **Organization (Tenant)** model
+2. **User ↔ Organization membership** (many-to-many)
+3. OIDC authentication via IdentityServer
+4. RBAC (roles + permissions) scoped to organization
+5. ABAC (contextual policies) for high-risk operations
+6. Deny-by-default, fail-closed, backend as sole security boundary
+7. Admin Panel contract-compatible with backend (OpenAPI-driven)
+8. Ready for Entitlements (Pay-As-You-Go) and BNPL permissions later
+
+### Non-Goals (this ADR)
+
+- Replacing or modifying API Key auth
+- Full billing / metering implementation
+- Full BNPL domain
+- External policy engine (OPA / OpenFGA) in v1
+- Organization hierarchy deeper than Platform → Organization (defer workspace hierarchy)
+
+---
+
+## Decision
+
+### 1. Architectural principle
+
+Identity and Authorization are a **platform capability**, not an Admin Panel feature.
+
+```text
+Admin UI (Next.js)
+      │  OIDC / OAuth2 (Auth Code + PKCE)
+      ▼
+IdentityServer
+  (authentication, token issuance, session, MFA readiness)
+      │  Access Token (JWT)
+      ▼
+Backend API (NotificationHub.Host)
+  (token validation, tenant context, RBAC, ABAC, entitlements, domain rules)
+      │
+      ├── Identity / Membership store
+      ├── Domain data (tenant-scoped)
+      └── Redis (revocation / session cache only)
+```
+
+- IdentityServer proves **who** the actor is.
+- Backend decides **what** the actor may do.
+- Tenant boundary determines **where**.
+- API Key path stays independent for machine clients.
+
+### 2. Organization = Tenant
+
+In this product, **Organization** is the commercial and isolation unit (the customer company).
+
+```text
+Platform
+ └── Organization (Tenant)
+      ├── Memberships (Users)
+      ├── Roles / Permissions
+      ├── API Keys (existing — unchanged)
+      ├── Domain data (notifications, templates, campaigns, …)
+      ├── Subscription / Entitlements (future)
+      └── Security policy
+```
+
+Every tenant-owned entity implements a tenant boundary (strongly typed `OrganizationId` / `TenantId`).
+
+### 3. User–Organization relationship
+
+Not 1:1. Use membership:
+
+```text
+User
+ └── OrganizationMembership
+      ├── OrganizationId
+      ├── UserId
+      ├── Status: Invited | Pending | Active | Suspended | Revoked
+      ├── Roles
+      ├── JoinedAt / RevokedAt
+```
+
+One user may belong to multiple organizations with different roles.
+
+### 4. Authentication (humans)
+
+- IdentityServer as OIDC + OAuth Authorization Server
+- Admin UI: Authorization Code Flow + PKCE
+- No Resource Owner Password Credentials for the browser app
+- Separate: Identity Token / Access Token / Refresh Token
+- Access token carries minimal claims:
+
+```text
+sub, client_id, tenant_id (active org), scope, role (or role names),
+jti, iat, exp, iss, aud, amr
+```
+
+Do **not** embed large permission lists in JWT. Resolve permissions server-side.
+
+### 5. Tenant (Organization) context
+
+Active organization is explicit in the access token (`tenant_id`).
+
+Tenant switch:
+
+1. Verify active membership in target org
+2. Verify org is active
+3. Issue new access token with new `tenant_id`
+4. Audit the switch
+
+Never trust raw `X-Tenant-Id` alone for human sessions.
+
+Canonical abstractions:
+
+```csharp
+ITenantContext   // OrganizationId, UserId, MembershipId
+ISecurityContext // roles, permissions, MFA, platform flag — immutable, server-derived
+```
+
+### 6. RBAC
+
+Business roles (examples):
+
+```text
+PlatformAdmin          // platform operators only
+OrganizationOwner
+OrganizationAdmin
+FinanceManager         // future billing / BNPL
+NotificationOperator   // send / campaigns
+SupportAgent
+Auditor
+Viewer
+```
+
+Permissions follow `resource.action`:
+
+```text
+notification.read | notification.send
+template.read | template.write | template.delete
+campaign.read | campaign.create | campaign.start | campaign.cancel
+member.invite | member.role.assign | member.suspend
+audit.read
+organization.read | organization.update
+// future
+bnpl.application.approve | settlement.execute | …
+```
+
+Mapping: Role → RolePermission → Permission (data-driven).
+Roles are **scoped** (Platform vs Organization). OrganizationAdmin never becomes PlatformAdmin by accident.
+
+### 7. ABAC
+
+RBAC = baseline capability. ABAC = contextual restriction.
+
+Example:
+
+```text
+Permission: campaign.start
+ABAC: membership active AND org active AND (optional) entitlement campaigns.enabled
+```
+
+High-risk future ops (refund-style / limit override) use handlers that check amount, MFA, time, risk — without exploding role count.
+
+Start with ASP.NET Core `IAuthorizationService` + policy provider + handlers. External engines only if policies become non-developer-managed.
+
+### 8. Authorization pipeline (human path)
+
+```text
+HTTP Request
+ → Authentication (JWT Bearer)
+ → Token validation (iss, aud, exp, signature)
+ → Tenant resolution from token
+ → Membership validation (active)
+ → Permission evaluation
+ → Entitlement (when introduced)
+ → Resource scope (tenant isolation)
+ → ABAC / domain rules
+ → Handler
+```
+
+Deny by default. Fail closed if membership/policy store unavailable.
+
+### 9. Dual auth on Host
+
+| Path | Mechanism |
+|------|-----------|
+| Machine API (`/api/v1/notifications`, …) | Existing API Key middleware — **unchanged** |
+| Human Admin API (`/api/v1/auth/*`, `/api/v1/organizations/*`, members, …) | JWT Bearer |
+| Some admin read endpoints | JWT only (or explicit policy) |
+
+API Key roles stay as today for machine clients. Human RBAC is a separate permission space (or carefully mapped later if needed).
+
+### 10. Sessions & tokens
+
+- Short-lived access tokens (e.g. 5–15 min)
+- Refresh token rotation + server-side session
+- Store only hashed refresh tokens
+- Logout revokes session + refresh family
+- Optional JTI revocation list in Redis for immediate access-token kill
+
+### 11. Admin Panel rules
+
+- UI hides/disables actions based on permissions from `GET /auth/me` (or equivalent)
+- UI is **never** the security boundary
+- Routes and DTOs follow OpenAPI; no invented contracts
+- Prefer BFF / HttpOnly session for production Admin UI when feasible
+
+### 12. Data model (minimum)
+
+```text
+Users
+Organizations
+OrganizationMemberships
+Roles
+Permissions
+RolePermissions
+MembershipRoles
+UserSessions
+RefreshTokens (hashed)
+SecurityEvents / AuditEvents
+Invitations
+OrganizationEntitlements (phase later)
+```
+
+Soft-delete / status for identity records; financial/domain history must not cascade-delete with users.
+
+### 13. Implementation order
+
+See backlog document: [docs/backlog/multi-tenant-identity.md](backlog/multi-tenant-identity.md).
+
+Backend first, then `apps/admin`.
+
+### 14. Explicit constraints
+
+1. **Do not modify API Key authentication or its roles.**
+2. Do not put domain/payment rules into IdentityServer.
+3. Do not put large permission sets into JWTs.
+4. Do not trust client-supplied organization id without membership check.
+5. Do not use frontend guards as authorization.
+6. Keep identity, authorization, entitlement, billing, and domain modules separate.
+
+---
+
+## Alternatives considered
+
+| Alternative | Why not |
+|-------------|---------|
+| Extend API Key to human admin login | Wrong tool; no SSO, MFA, session, org switching |
+| Single shared “admin password” per org | Insecure; no per-user audit |
+| Put all permissions in JWT | Token size, staleness, hard to revoke |
+| Trust `X-Tenant-Id` header only | Spoofing / IDOR risk |
+| OPA/OpenFGA from day one | Premature; ASP.NET policies sufficient for v1 |
+| One user = one organization | Blocks partners / consultants / multi-org operators |
+
+---
+
+## Consequences
+
+### Positive
+
+- Clear separation: machine (API Key) vs human (OIDC)
+- Sellable multi-org product with delegated user management
+- Path to entitlements and BNPL without redesigning auth
+- Auditable membership and authorization decisions
+
+### Negative / costs
+
+- New IdentityServer (or Duende / OpenIddict) host and operational complexity
+- Schema and migrations for identity tables
+- Dual authentication paths on the API host
+- Admin UI rewrite of session/auth flow
+
+### Risks
+
+- Stale JWT permissions → mitigate with short TTL + server-side permission checks
+- Accidental cross-org access → mandatory membership + resource tenant checks + regression tests
+- Confusion between API Key roles and human permissions → document and keep namespaces separate
+
+---
+
+## References
+
+- Skill: Multi-Tenant Identity, Authentication, RBAC & ABAC (design source)
+- ADR-008 Domain UoW and Tenant Partition
+- Existing `OidcOptions`, `IRequestContext`, `ApiKeyAuthMiddleware` (leave API Key intact)
+- OpenID Connect / OAuth 2.1 best practices

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ ADRs capture **why** a decision was made, alternatives considered, and consequen
 | 011 | [ADR-011-Batch-Broadcast-Campaigns.md](ADR-011-Batch-Broadcast-Campaigns.md) | Accepted | Campaign + recipients + dispatch worker |
 | 012 | [ADR-012-Aspire-Composition-vs-Business-Orchestration.md](ADR-012-Aspire-Composition-vs-Business-Orchestration.md) | Accepted | Aspire ≠ business orchestration |
 | 013 | [ADR-013-Per-Channel-Delivery-Workers.md](ADR-013-Per-Channel-Delivery-Workers.md) | Accepted | Separate email/sms/push consumers |
+| 019 | [ADR-019-Multi-Tenant-Identity-RBAC-ABAC.md](ADR-019-Multi-Tenant-Identity-RBAC-ABAC.md) | Proposed | B2B org identity, OIDC, RBAC/ABAC (API Key unchanged) |
 
 ### Writing a new ADR
 
@@ -21,6 +22,10 @@ ADRs capture **why** a decision was made, alternatives considered, and consequen
 2. Use the next free number (`ADR-0NN-...`).
 3. Link it from this index and from the root [README](../README.md).
 4. Prefer amending an existing ADR with a dated **Amendment** section when changing an Accepted decision, rather than rewriting history silently.
+
+## Backlogs
+
+- [Multi-tenant identity (backend-first)](backlog/multi-tenant-identity.md)
 
 ## Operations
 

--- a/docs/backlog/multi-tenant-identity.md
+++ b/docs/backlog/multi-tenant-identity.md
@@ -1,0 +1,147 @@
+# Backlog: Multi-Tenant Identity (B2B IaaS)
+
+Source: [ADR-019](../ADR-019-Multi-Tenant-Identity-RBAC-ABAC.md)
+
+**Constraint:** API Key authentication remains untouched (machine clients).
+
+**Order:** Backend complete before Admin UI (`apps/admin`).
+
+---
+
+## Epic A — Foundation (Backend)
+
+### A1. Domain model & persistence
+| ID | Item | Priority | Notes |
+|----|------|----------|-------|
+| A1.1 | `Organization` entity (Id, Name, Status, Type, CreatedAt, SecurityPolicy ref) | P0 | Tenant = Organization |
+| A1.2 | `User` entity (Id, Email, DisplayName, Status, CreatedAt) | P0 | Email is attribute, not immutable id |
+| A1.3 | `OrganizationMembership` (OrgId, UserId, Status lifecycle, timestamps) | P0 | Invited→Pending→Active→Suspended→Revoked |
+| A1.4 | `Role`, `Permission`, `RolePermission`, `MembershipRole` | P0 | Data-driven mapping |
+| A1.5 | `Invitation` (token hash, expires, single-use) | P0 | |
+| A1.6 | EF configurations + migration(s) | P0 | No cascade-delete of domain history |
+| A1.7 | Seed default permissions + system roles | P0 | |
+
+### A2. Identity host / token issuer
+| ID | Item | Priority | Notes |
+|----|------|----------|-------|
+| A2.1 | Choose stack: Duende IdentityServer **or** OpenIddict (document choice in ADR amendment) | P0 | |
+| A2.2 | Identity host project (or AppHost service) | P0 | Separate process preferred |
+| A2.3 | OIDC clients: `admin-ui` (Auth Code + PKCE), optional `admin-bff` | P0 | |
+| A2.4 | Scopes: `openid`, `profile`, `email`, `notificationhub.admin` | P0 | |
+| A2.5 | Access token claims: `sub`, `tenant_id`, `client_id`, roles (minimal), `jti`, standard OIDC | P0 | No fat permission arrays |
+| A2.6 | Refresh token rotation + hashed storage | P0 | |
+| A2.7 | Signing key config + rotation readiness (JWKS) | P1 | |
+| A2.8 | MFA readiness hooks (policy-driven, not hard-coded) | P2 | |
+
+### A3. API authentication & context (Host)
+| ID | Item | Priority | Notes |
+|----|------|----------|-------|
+| A3.1 | JWT Bearer authentication scheme **alongside** existing API Key middleware | P0 | Do not change API Key |
+| A3.2 | Audience / issuer validation | P0 | |
+| A3.3 | `ITenantContext` + `ISecurityContext` (immutable, server-derived) | P0 | |
+| A3.4 | Membership validation on every human request | P0 | Fail closed |
+| A3.5 | Organization switch endpoint → new token with new `tenant_id` | P0 | |
+| A3.6 | Map human principal into `IRequestContext` without breaking API Key path | P0 | |
+
+### A4. RBAC / ABAC
+| ID | Item | Priority | Notes |
+|----|------|----------|-------|
+| A4.1 | Permission catalog (`resource.action`) for current domain | P0 | notification, template, campaign, member, org, audit |
+| A4.2 | Dynamic policy provider (permission name → policy) | P0 | |
+| A4.3 | Authorization handlers: permission + same-org resource | P0 | |
+| A4.4 | `[Authorize(Policy = "…")]` / endpoint filters for new admin routes | P0 | |
+| A4.5 | ABAC sample: membership status + org status | P1 | |
+| A4.6 | Deny-by-default + regression tests (cross-org IDOR) | P0 | |
+
+### A5. Human admin API surface
+| ID | Item | Priority | Notes |
+|----|------|----------|-------|
+| A5.1 | `GET /api/v1/auth/me` — user, active org, roles, permissions | P0 | Contract for Admin UI |
+| A5.2 | `GET /api/v1/auth/organizations` — memberships | P0 | |
+| A5.3 | `POST /api/v1/auth/organizations/switch` | P0 | |
+| A5.4 | `POST /api/v1/auth/logout` — revoke session/refresh | P0 | |
+| A5.5 | Organization CRUD (platform + owner scoped) | P0 | |
+| A5.6 | Invite member / accept invitation | P0 | |
+| A5.7 | Assign/remove roles on membership | P0 | |
+| A5.8 | Suspend / reactivate / revoke membership | P0 | |
+| A5.9 | List sessions / revoke session | P1 | |
+| A5.10 | OpenAPI update for all new endpoints | P0 | |
+
+### A6. Audit & security ops
+| ID | Item | Priority | Notes |
+|----|------|----------|-------|
+| A6.1 | Security events: login, logout, switch org, invite, role change, deny | P0 | No secrets in logs |
+| A6.2 | Append-only audit store (or reuse Core.Audit with clear category) | P1 | |
+| A6.3 | Rate limit login / token / invite / password-reset | P1 | |
+| A6.4 | Metrics: auth success/fail, authz deny, refresh reuse | P2 | |
+
+### A7. Future readiness (schema only or stubs)
+| ID | Item | Priority | Notes |
+|----|------|----------|-------|
+| A7.1 | `OrganizationEntitlement` table + check hook in auth pipeline | P2 | Pay-As-You-Go |
+| A7.2 | Permission names reserved for BNPL (document only) | P2 | |
+| A7.3 | Platform vs Organization role scope enforced | P0 | |
+
+---
+
+## Epic B — Admin UI (`apps/admin`) — **after** backend contracts stable
+
+| ID | Item | Priority | Notes |
+|----|------|----------|-------|
+| B1 | OIDC login (Auth Code + PKCE) against Identity host | P0 | |
+| B2 | Session handling (prefer BFF/HttpOnly if adopted; else documented SPA risks) | P0 | |
+| B3 | Tenant selector after login (multi-org) | P0 | |
+| B4 | Load `/auth/me` → permission context for UI | P0 | UX only |
+| B5 | Route guards from permission metadata | P1 | |
+| B6 | Members / invite / roles screens | P0 | |
+| B7 | Organization settings screen | P1 | |
+| B8 | Generated API client from OpenAPI | P0 | No hand-rolled DTOs |
+| B9 | Logout + session revoke | P0 | |
+
+---
+
+## Epic C — Quality gates
+
+| ID | Item | Priority |
+|----|------|----------|
+| C1 | Auth tests: invalid/expired token, wrong audience, wrong issuer | P0 |
+| C2 | Tenant isolation: Org A cannot read Org B resources | P0 |
+| C3 | RBAC: Viewer cannot mutate; OrgAdmin cannot escalate to PlatformAdmin | P0 |
+| C4 | Membership lifecycle: suspended/revoked cannot act | P0 |
+| C5 | Invitation: expired / reused rejected | P0 |
+| C6 | API Key path regression: existing machine flows still pass | P0 |
+| C7 | Contract tests Admin ↔ OpenAPI | P1 |
+
+---
+
+## Suggested sprint slices (backend-first)
+
+### Sprint 1 — Model + Identity host skeleton
+- A1.*, A2.1–A2.5, A3.1–A3.3
+
+### Sprint 2 — Membership + switch + `/auth/me`
+- A3.4–A3.6, A5.1–A5.4, A5.6, A6.1
+
+### Sprint 3 — RBAC on admin APIs + org/member management
+- A4.*, A5.5, A5.7–A5.8, A5.10, C1–C6
+
+### Sprint 4 — Sessions, hardening, OpenAPI freeze
+- A2.6–A2.7, A5.9, A6.2–A6.3, C7
+
+### Sprint 5+ — Admin UI Epic B
+
+### Later — Entitlements / BNPL (A7, domain features)
+
+---
+
+## Definition of Done (identity vertical)
+
+- [ ] Humans authenticate via OIDC; machines still use API Key unchanged
+- [ ] Organization + membership lifecycle works
+- [ ] Active org in token; switch audited and membership-checked
+- [ ] Permissions enforced on admin APIs (deny-by-default)
+- [ ] Cross-org isolation tested
+- [ ] `/auth/me` (or equivalent) drives Admin UI
+- [ ] OpenAPI matches implementation
+- [ ] Security events audited without leaking secrets
+- [ ] Admin UI only after backend contracts are stable

--- a/docs/openapi/identity-v1-freeze.md
+++ b/docs/openapi/identity-v1-freeze.md
@@ -1,0 +1,48 @@
+# OpenAPI freeze — Identity human surface (Sprint 4)
+
+Contract for Admin UI (`apps/admin`). Machine API Key routes are **out of scope**.
+
+Base path: `/api/v1`
+Auth: `Authorization: Bearer <access_token>` (OIDC from Identity host)
+
+## Auth
+
+| Method | Path | Response highlights |
+|--------|------|---------------------|
+| GET | `/auth/me` | `{ user, tenant, membershipId, roles, permissions }` |
+| GET | `/auth/organizations` | `[{ membershipId, organizationId, name, organizationStatus, membershipStatus, roles }]` |
+| POST | `/auth/organizations/switch` | body `{ organizationId }` → `{ organizationId, membershipId, roles, permissions }` |
+| POST | `/auth/logout` | 204 |
+| POST | `/auth/invitations` | body `{ email, roleName?, organizationId? }` → 201 `{ id }` |
+| POST | `/auth/invitations/accept` | body `{ token }` → 204 |
+| GET | `/auth/sessions` | `[{ id, organizationId, clientId, ip, userAgent, createdAt, lastSeenAt, expiresAt, isActive }]` |
+| DELETE | `/auth/sessions/{sessionId}` | 204 |
+| POST | `/auth/sessions/revoke-all` | 204 |
+
+## Organizations
+
+| Method | Path | Permission |
+|--------|------|------------|
+| POST | `/organizations` | PlatformAdmin |
+| GET | `/organizations/{id}` | organization.read |
+| PATCH | `/organizations/{id}` | organization.update |
+| GET | `/organizations/{id}/members` | member.read |
+| POST | `/organizations/{id}/members/{mid}/roles` | member.role.assign |
+| DELETE | `/organizations/{id}/members/{mid}/roles/{roleName}` | member.role.assign |
+| POST | `/organizations/{id}/members/{mid}/status` | member.suspend |
+
+## Errors
+
+- `401` unauthenticated
+- `403` `{ "error": "forbidden" | "membership_inactive_or_missing" | ... }`
+- `429` rate limited on sensitive auth routes
+
+## Token claims (Identity host)
+
+`sub`, `tenant_id`, `client_id`, `role` (minimal), `jti`, `iss`, `aud`, `exp`
+
+Permissions are **not** embedded in access token; loaded server-side via membership.
+
+## Status
+
+**Frozen for Admin UI Epic B** — additive changes only; breaking changes require ADR amendment.

--- a/docs/ops/sprint1-identity-wireup.md
+++ b/docs/ops/sprint1-identity-wireup.md
@@ -1,0 +1,60 @@
+# Sprint 1 wire-up checklist (Host)
+
+## 1. Make NotificationDbContext partial
+
+In `NotificationDbContext.cs` change:
+
+```csharp
+public sealed class NotificationDbContext
+```
+to:
+
+```csharp
+public partial class NotificationDbContext
+```
+
+At end of `OnModelCreating`:
+
+```csharp
+ConfigureIdentity(modelBuilder);
+```
+
+## 2. Program.cs (Host)
+
+After `builder.Services.Configure<OidcOptions>(...)`:
+
+```csharp
+builder.Services.AddNotificationHubJwtBearer(builder.Configuration);
+```
+
+After existing schema ensures (Phase1Schema, …):
+
+```csharp
+await IdentitySchema.EnsureAsync(db, startupLog);
+```
+
+`using NotificationHub.Core.Identity;`
+`using NotificationHub.Host.Security;`
+
+## 3. appsettings (optional enable)
+
+```json
+"Auth": {
+  "JwtBearer": {
+    "Enabled": false,
+    "Authority": "https://localhost:5xxx",
+    "Audience": "notificationhub-api",
+    "RequireHttpsMetadata": false
+  }
+}
+```
+
+Keep `Enabled: false` until Identity host runs.
+
+## 4. Solution
+
+Add `src/Host/NotificationHub.Identity/NotificationHub.Identity.csproj` to solution under Host folder.
+
+## Stack choice
+
+OpenIddict (free) — see Identity host project.

--- a/docs/ops/sprint2-identity-wireup.md
+++ b/docs/ops/sprint2-identity-wireup.md
@@ -1,0 +1,49 @@
+# Sprint 2 wire-up (Host Program.cs)
+
+## 1. ApiKeyAuthMiddleware — dual auth pass-through
+
+At start of `InvokeAsync`, after health/swagger checks:
+
+```csharp
+if (DualAuthPassThrough.ShouldSkipApiKey(context))
+{
+    await _next(context);
+    return;
+}
+```
+
+API Key validation for machine clients is unchanged.
+
+## 2. Map endpoints
+
+After other maps:
+
+```csharp
+app.MapIdentityAuthEndpoints();
+```
+
+Requires JWT (`AddNotificationHubJwtBearer`). When JwtBearer Enabled, also:
+
+```csharp
+app.UseAuthentication();
+app.UseAuthorization();
+```
+
+Place **after** CORS, **before or after** ApiKey middleware as appropriate:
+- ApiKey middleware runs first; skips when Bearer or `/api/v1/auth`.
+- Then `UseAuthentication` validates JWT for human routes.
+
+## 3. DI
+
+`MembershipService` is picked up by Scrutor (`*Service` → `IMembershipService`) via `AddCorePlatform()`.
+
+## Endpoints
+
+| Method | Path | Auth |
+|--------|------|------|
+| GET | /api/v1/auth/me | JWT |
+| GET | /api/v1/auth/organizations | JWT |
+| POST | /api/v1/auth/organizations/switch | JWT |
+| POST | /api/v1/auth/logout | JWT |
+| POST | /api/v1/auth/invitations | JWT + member.invite |
+| POST | /api/v1/auth/invitations/accept | JWT |

--- a/docs/ops/sprint3-identity-wireup.md
+++ b/docs/ops/sprint3-identity-wireup.md
@@ -1,0 +1,32 @@
+# Sprint 3 wire-up
+
+## Program.cs
+
+```csharp
+builder.Services.AddNotificationHubJwtBearer(builder.Configuration);
+builder.Services.AddNotificationHubRbac();
+```
+
+```csharp
+app.MapIdentityAuthEndpoints();
+app.MapOrganizationAdminEndpoints();
+```
+
+## Endpoints
+
+| Method | Path | Permission |
+|--------|------|------------|
+| POST | /api/v1/organizations | PlatformAdmin |
+| GET | /api/v1/organizations/{id} | organization.read |
+| PATCH | /api/v1/organizations/{id} | organization.update |
+| GET | /api/v1/organizations/{id}/members | member.read |
+| POST | .../members/{mid}/roles | member.role.assign |
+| DELETE | .../members/{mid}/roles/{name} | member.role.assign |
+| POST | .../members/{mid}/status | member.suspend |
+
+## Guarantees
+
+- Deny-by-default (no permission → 403)
+- PlatformAdmin cannot be assigned via org member role API
+- Suspended/revoked membership fails `GetActiveMembershipAsync`
+- API Key machine path unchanged

--- a/docs/ops/sprint4-identity-wireup.md
+++ b/docs/ops/sprint4-identity-wireup.md
@@ -1,0 +1,29 @@
+# Sprint 4 wire-up
+
+## Program.cs (API Host)
+
+```csharp
+app.UseMiddleware<AuthRateLimitMiddleware>(); // after correlation, before/after ApiKey as preferred
+app.MapIdentityAuthEndpoints();
+app.MapSessionEndpoints();
+app.MapOrganizationAdminEndpoints();
+```
+
+## DI
+
+`SessionService` registered via Scrutor (`*Service` → interface).
+
+## Identity host
+
+- Configure `Identity:Signing:RsaPrivateKeyPem` + `KeyId` in production.
+- Expose JWKS for API `AddNotificationHubJwtBearer` Authority validation.
+- On token issue: call `ISessionService.CreateAsync` with raw refresh (hash only stored).
+- On refresh: `RotateRefreshTokenAsync` — single-use rotation, fail-closed on reuse.
+
+## Rate limits
+
+`RateLimiting:AuthSensitivePerMinute` (default 20) for invite / switch / logout / sessions.
+
+## OpenAPI
+
+See `docs/openapi/identity-v1-freeze.md` — Admin UI must generate client from this contract.

--- a/docs/ops/sprint5-admin-ui.md
+++ b/docs/ops/sprint5-admin-ui.md
@@ -1,0 +1,25 @@
+# Sprint 5+ — Admin UI (Epic B)
+
+## Delivered
+
+| ID | Item |
+|----|------|
+| B1 | OIDC Auth Code + PKCE (`lib/auth/oidc.ts`) |
+| B2 | Session in localStorage (documented SPA risk) |
+| B3 | Org selector in topbar from `/auth/organizations` |
+| B4 | `AuthProvider` loads `/auth/me` + permissions |
+| B5 | `RequireAuth` / `RequirePermission` |
+| B6 | Members + invite + suspend (`/organization/members`) |
+| B7 | Org settings (`/organization/settings`) |
+| B8 | `lib/api/identity.ts` aligned to OpenAPI freeze |
+| B9 | Logout + `/account/sessions` revoke |
+
+## Env
+
+See `apps/admin/.env.example`.
+
+## Notes
+
+- UI permissions are UX only; API enforces deny-by-default.
+- After org switch, Identity host should re-issue token with new `tenant_id` (API returns membership confirmation).
+- Shell still renders on `/login`; auth gate skips redirect loop via PUBLIC paths.

--- a/src/BuildingBlocks/NotificationHub.Core/Auth/JwtBearerOptions.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Auth/JwtBearerOptions.cs
@@ -1,0 +1,14 @@
+namespace NotificationHub.Core.Auth;
+
+/// <summary>JWT validation for human Admin API (alongside API Key — does not replace it).</summary>
+public sealed class JwtBearerAuthOptions
+{
+    public const string SectionName = "Auth:JwtBearer";
+
+    public bool Enabled { get; set; }
+    public string Authority { get; set; } = "";
+    public string Audience { get; set; } = "notificationhub-api";
+    public bool RequireHttpsMetadata { get; set; } = true;
+    /// <summary>Claim type for active organization id.</summary>
+    public string TenantClaimType { get; set; } = "tenant_id";
+}

--- a/src/BuildingBlocks/NotificationHub.Core/Identity/IMembershipService.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Identity/IMembershipService.cs
@@ -1,0 +1,40 @@
+namespace NotificationHub.Core.Identity;
+
+public interface IMembershipService
+{
+    Task<MembershipSnapshot?> GetActiveMembershipAsync(Guid userId, Guid organizationId, CancellationToken ct = default);
+    Task<IReadOnlyList<OrganizationMembershipDto>> ListMembershipsAsync(Guid userId, CancellationToken ct = default);
+    Task<AuthMeDto?> GetMeAsync(Guid userId, Guid? organizationId, CancellationToken ct = default);
+    Task<InviteResult> InviteAsync(Guid organizationId, string email, string? roleName, Guid invitedByUserId, CancellationToken ct = default);
+    Task<bool> AcceptInviteAsync(string rawToken, Guid userId, CancellationToken ct = default);
+    Task RevokeSessionAsync(Guid userId, Guid? sessionId, string? jwtId, CancellationToken ct = default);
+    Task RecordSecurityEventAsync(string action, Guid? userId, Guid? organizationId, string? details, CancellationToken ct = default);
+}
+
+public sealed record MembershipSnapshot(
+    Guid MembershipId,
+    Guid OrganizationId,
+    Guid UserId,
+    string Status,
+    IReadOnlyList<string> Roles,
+    IReadOnlyList<string> Permissions);
+
+public sealed record OrganizationMembershipDto(
+    Guid MembershipId,
+    Guid OrganizationId,
+    string OrganizationName,
+    string OrganizationStatus,
+    string MembershipStatus,
+    IReadOnlyList<string> Roles);
+
+public sealed record AuthMeDto(
+    Guid UserId,
+    string Email,
+    string? DisplayName,
+    Guid? OrganizationId,
+    string? OrganizationName,
+    Guid? MembershipId,
+    IReadOnlyList<string> Roles,
+    IReadOnlyList<string> Permissions);
+
+public sealed record InviteResult(bool Success, Guid? InvitationId, string? Error);

--- a/src/BuildingBlocks/NotificationHub.Core/Identity/IOrganizationAdminService.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Identity/IOrganizationAdminService.cs
@@ -1,0 +1,15 @@
+namespace NotificationHub.Core.Identity;
+
+public interface IOrganizationAdminService
+{
+    Task<OrganizationDto?> GetAsync(Guid organizationId, CancellationToken ct = default);
+    Task<OrganizationDto> CreateAsync(string name, string? slug, string type, CancellationToken ct = default);
+    Task<OrganizationDto?> UpdateAsync(Guid organizationId, string? name, string? status, CancellationToken ct = default);
+    Task<IReadOnlyList<MemberDto>> ListMembersAsync(Guid organizationId, CancellationToken ct = default);
+    Task<bool> AssignRoleAsync(Guid membershipId, string roleName, CancellationToken ct = default);
+    Task<bool> RemoveRoleAsync(Guid membershipId, string roleName, CancellationToken ct = default);
+    Task<bool> SetMembershipStatusAsync(Guid membershipId, string status, CancellationToken ct = default);
+}
+
+public sealed record OrganizationDto(Guid Id, string Name, string? Slug, string Type, string Status);
+public sealed record MemberDto(Guid MembershipId, Guid UserId, string Email, string? DisplayName, string Status, IReadOnlyList<string> Roles);

--- a/src/BuildingBlocks/NotificationHub.Core/Identity/ISecurityContext.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Identity/ISecurityContext.cs
@@ -1,0 +1,48 @@
+namespace NotificationHub.Core.Identity;
+
+/// <summary>Immutable, server-derived security snapshot for the current request.</summary>
+public interface ISecurityContext
+{
+    Guid? UserId { get; }
+    Guid? OrganizationId { get; }
+    Guid? MembershipId { get; }
+    IReadOnlyCollection<string> Roles { get; }
+    IReadOnlyCollection<string> Permissions { get; }
+    bool IsAuthenticated { get; }
+    bool IsPlatformUser { get; }
+    bool IsMfaSatisfied { get; }
+    bool HasPermission(string permission);
+    bool HasAnyRole(params string[] roles);
+}
+
+public sealed class NullSecurityContext : ISecurityContext
+{
+    public Guid? UserId => null;
+    public Guid? OrganizationId => null;
+    public Guid? MembershipId => null;
+    public IReadOnlyCollection<string> Roles => Array.Empty<string>();
+    public IReadOnlyCollection<string> Permissions => Array.Empty<string>();
+    public bool IsAuthenticated => false;
+    public bool IsPlatformUser => false;
+    public bool IsMfaSatisfied => false;
+    public bool HasPermission(string permission) => false;
+    public bool HasAnyRole(params string[] roles) => false;
+}
+
+public sealed class SecurityContext : ISecurityContext
+{
+    public required Guid? UserId { get; init; }
+    public required Guid? OrganizationId { get; init; }
+    public required Guid? MembershipId { get; init; }
+    public required IReadOnlyCollection<string> Roles { get; init; }
+    public required IReadOnlyCollection<string> Permissions { get; init; }
+    public required bool IsAuthenticated { get; init; }
+    public required bool IsPlatformUser { get; init; }
+    public bool IsMfaSatisfied { get; init; }
+
+    public bool HasPermission(string permission) =>
+        Permissions.Contains(permission, StringComparer.OrdinalIgnoreCase);
+
+    public bool HasAnyRole(params string[] roles) =>
+        roles.Any(r => Roles.Contains(r, StringComparer.OrdinalIgnoreCase));
+}

--- a/src/BuildingBlocks/NotificationHub.Core/Identity/ISessionService.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Identity/ISessionService.cs
@@ -1,0 +1,39 @@
+namespace NotificationHub.Core.Identity;
+
+public interface ISessionService
+{
+    Task<IReadOnlyList<SessionDto>> ListAsync(Guid userId, CancellationToken ct = default);
+    Task<bool> RevokeAsync(Guid userId, Guid sessionId, CancellationToken ct = default);
+    Task RevokeAllAsync(Guid userId, CancellationToken ct = default);
+    Task<SessionDto> CreateAsync(CreateSessionRequest request, CancellationToken ct = default);
+    Task<RefreshResult> RotateRefreshTokenAsync(string rawRefreshToken, CancellationToken ct = default);
+}
+
+public sealed record SessionDto(
+    Guid Id,
+    Guid? OrganizationId,
+    string? ClientId,
+    string? Ip,
+    string? UserAgent,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset LastSeenAt,
+    DateTimeOffset ExpiresAt,
+    bool IsActive,
+    bool IsCurrent);
+
+public sealed record CreateSessionRequest(
+    Guid UserId,
+    Guid? OrganizationId,
+    string? ClientId,
+    string JwtId,
+    string RawRefreshToken,
+    string? Ip,
+    string? UserAgent,
+    TimeSpan Lifetime);
+
+public sealed record RefreshResult(
+    bool Success,
+    Guid? UserId,
+    Guid? OrganizationId,
+    string? NewRawRefreshToken,
+    string? Error);

--- a/src/BuildingBlocks/NotificationHub.Core/Identity/ITenantContext.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Identity/ITenantContext.cs
@@ -1,0 +1,17 @@
+namespace NotificationHub.Core.Identity;
+
+/// <summary>Active organization context for the current request (human JWT path).</summary>
+public interface ITenantContext
+{
+    Guid? OrganizationId { get; }
+    Guid? UserId { get; }
+    Guid? MembershipId { get; }
+    bool HasOrganization => OrganizationId is not null;
+}
+
+public sealed class NullTenantContext : ITenantContext
+{
+    public Guid? OrganizationId => null;
+    public Guid? UserId => null;
+    public Guid? MembershipId => null;
+}

--- a/src/BuildingBlocks/NotificationHub.Core/Identity/IdentityEntities.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Identity/IdentityEntities.cs
@@ -1,0 +1,101 @@
+namespace NotificationHub.Core.Identity;
+
+/// <summary>B2B customer company — isolation unit (Tenant).</summary>
+public sealed class OrganizationEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = "";
+    public string? Slug { get; set; }
+    /// <summary>Merchant | Enterprise | Partner | Platform | …</summary>
+    public string Type { get; set; } = "Merchant";
+    /// <summary>Active | Suspended | Closed</summary>
+    public string Status { get; set; } = "Active";
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+}
+
+/// <summary>Human identity. Email is an attribute, not the immutable key.</summary>
+public sealed class IdentityUserEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Email { get; set; } = "";
+    public string? DisplayName { get; set; }
+    public string? Phone { get; set; }
+    /// <summary>Active | Locked | Suspended | Disabled | Deleted</summary>
+    public string Status { get; set; } = "Active";
+    public string? PasswordHash { get; set; }
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+}
+
+/// <summary>User ↔ Organization membership with lifecycle.</summary>
+public sealed class OrganizationMembershipEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid OrganizationId { get; set; }
+    public Guid UserId { get; set; }
+    /// <summary>Invited | Pending | Active | Suspended | Revoked</summary>
+    public string Status { get; set; } = "Invited";
+    public DateTimeOffset JoinedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset? RevokedAt { get; set; }
+}
+
+public sealed class IdentityRoleEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Name { get; set; } = "";
+    /// <summary>Platform | Organization</summary>
+    public string Scope { get; set; } = "Organization";
+    public string? Description { get; set; }
+    public bool IsSystem { get; set; }
+}
+
+public sealed class IdentityPermissionEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    /// <summary>resource.action e.g. notification.send</summary>
+    public string Name { get; set; } = "";
+    public string? Description { get; set; }
+}
+
+public sealed class RolePermissionEntity
+{
+    public Guid RoleId { get; set; }
+    public Guid PermissionId { get; set; }
+}
+
+public sealed class MembershipRoleEntity
+{
+    public Guid MembershipId { get; set; }
+    public Guid RoleId { get; set; }
+}
+
+public sealed class InvitationEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid OrganizationId { get; set; }
+    public string Email { get; set; } = "";
+    public string TokenHash { get; set; } = "";
+    public Guid? InvitedByUserId { get; set; }
+    public string? RoleName { get; set; }
+    public DateTimeOffset ExpiresAt { get; set; }
+    public DateTimeOffset? AcceptedAt { get; set; }
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+}
+
+public sealed class UserSessionEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid UserId { get; set; }
+    public Guid? OrganizationId { get; set; }
+    public string? ClientId { get; set; }
+    public string? JwtId { get; set; }
+    public string? RefreshTokenHash { get; set; }
+    public string? Ip { get; set; }
+    public string? UserAgent { get; set; }
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset LastSeenAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset ExpiresAt { get; set; }
+    public DateTimeOffset? RevokedAt { get; set; }
+    public bool IsActive { get; set; } = true;
+}

--- a/src/BuildingBlocks/NotificationHub.Core/Identity/IdentityPermissions.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Identity/IdentityPermissions.cs
@@ -1,0 +1,47 @@
+namespace NotificationHub.Core.Identity;
+
+/// <summary>Canonical permission names (resource.action). Seeded at startup.</summary>
+public static class IdentityPermissions
+{
+    public const string NotificationRead = "notification.read";
+    public const string NotificationSend = "notification.send";
+
+    public const string TemplateRead = "template.read";
+    public const string TemplateWrite = "template.write";
+    public const string TemplateDelete = "template.delete";
+
+    public const string CampaignRead = "campaign.read";
+    public const string CampaignCreate = "campaign.create";
+    public const string CampaignStart = "campaign.start";
+    public const string CampaignCancel = "campaign.cancel";
+
+    public const string MemberInvite = "member.invite";
+    public const string MemberRoleAssign = "member.role.assign";
+    public const string MemberSuspend = "member.suspend";
+    public const string MemberRead = "member.read";
+
+    public const string OrganizationRead = "organization.read";
+    public const string OrganizationUpdate = "organization.update";
+
+    public const string AuditRead = "audit.read";
+
+    public static IReadOnlyList<string> All { get; } =
+    [
+        NotificationRead, NotificationSend,
+        TemplateRead, TemplateWrite, TemplateDelete,
+        CampaignRead, CampaignCreate, CampaignStart, CampaignCancel,
+        MemberInvite, MemberRoleAssign, MemberSuspend, MemberRead,
+        OrganizationRead, OrganizationUpdate,
+        AuditRead
+    ];
+}
+
+public static class IdentityRoles
+{
+    public const string PlatformAdmin = "PlatformAdmin";
+    public const string OrganizationOwner = "OrganizationOwner";
+    public const string OrganizationAdmin = "OrganizationAdmin";
+    public const string NotificationOperator = "NotificationOperator";
+    public const string Viewer = "Viewer";
+    public const string Auditor = "Auditor";
+}

--- a/src/BuildingBlocks/NotificationHub.Core/Identity/IdentityPermissions.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Identity/IdentityPermissions.cs
@@ -21,6 +21,7 @@ public static class IdentityPermissions
     public const string MemberRead = "member.read";
 
     public const string OrganizationRead = "organization.read";
+    public const string OrganizationCreate = "organization.create";
     public const string OrganizationUpdate = "organization.update";
 
     public const string AuditRead = "audit.read";
@@ -31,7 +32,7 @@ public static class IdentityPermissions
         TemplateRead, TemplateWrite, TemplateDelete,
         CampaignRead, CampaignCreate, CampaignStart, CampaignCancel,
         MemberInvite, MemberRoleAssign, MemberSuspend, MemberRead,
-        OrganizationRead, OrganizationUpdate,
+        OrganizationRead, OrganizationCreate, OrganizationUpdate,
         AuditRead
     ];
 }

--- a/src/BuildingBlocks/NotificationHub.Core/Identity/IdentitySchema.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Identity/IdentitySchema.cs
@@ -9,7 +9,8 @@ public static class IdentitySchema
 {
     public static async Task EnsureAsync(NotificationDbContext db, ILogger? log = null, CancellationToken ct = default)
     {
-        await db.Database.ExecuteSqlRawAsync("""
+        await db.Database.ExecuteSqlRawAsync(
+            """
             CREATE TABLE IF NOT EXISTS identity_organizations (
                 "Id" uuid PRIMARY KEY,
                 "Name" varchar(256) NOT NULL,
@@ -102,7 +103,8 @@ public static class IdentitySchema
                 "IsActive" boolean NOT NULL DEFAULT true
             );
             CREATE INDEX IF NOT EXISTS ix_identity_sessions_user ON identity_sessions ("UserId") WHERE "IsActive" = true;
-            """, ct);
+            """,
+            ct);
 
         await SeedAsync(db, log, ct);
         log?.LogInformation("Identity schema ensured");
@@ -112,62 +114,110 @@ public static class IdentitySchema
     {
         foreach (var name in IdentityPermissions.All)
         {
-            if (await db.IdentityPermissions.AnyAsync(p => p.Name == name, ct))
+            if (await db.Set<IdentityPermissionEntity>().AnyAsync(p => p.Name == name, ct))
                 continue;
-            db.IdentityPermissions.Add(new IdentityPermissionEntity { Name = name });
+            db.Set<IdentityPermissionEntity>().Add(new IdentityPermissionEntity { Name = name });
         }
+
         await db.SaveChangesAsync(ct);
 
         await EnsureRoleAsync(db, IdentityRoles.PlatformAdmin, "Platform", true, IdentityPermissions.All, ct);
         await EnsureRoleAsync(db, IdentityRoles.OrganizationOwner, "Organization", true, IdentityPermissions.All, ct);
-        await EnsureRoleAsync(db, IdentityRoles.OrganizationAdmin, "Organization", true,
-        [
-            IdentityPermissions.NotificationRead, IdentityPermissions.NotificationSend,
-            IdentityPermissions.TemplateRead, IdentityPermissions.TemplateWrite, IdentityPermissions.TemplateDelete,
-            IdentityPermissions.CampaignRead, IdentityPermissions.CampaignCreate, IdentityPermissions.CampaignStart, IdentityPermissions.CampaignCancel,
-            IdentityPermissions.MemberInvite, IdentityPermissions.MemberRoleAssign, IdentityPermissions.MemberSuspend, IdentityPermissions.MemberRead,
-            IdentityPermissions.OrganizationRead, IdentityPermissions.OrganizationUpdate,
-            IdentityPermissions.AuditRead
-        ], ct);
-        await EnsureRoleAsync(db, IdentityRoles.NotificationOperator, "Organization", true,
-        [
-            IdentityPermissions.NotificationRead, IdentityPermissions.NotificationSend,
-            IdentityPermissions.TemplateRead, IdentityPermissions.TemplateWrite,
-            IdentityPermissions.CampaignRead, IdentityPermissions.CampaignCreate, IdentityPermissions.CampaignStart
-        ], ct);
-        await EnsureRoleAsync(db, IdentityRoles.Viewer, "Organization", true,
-        [
-            IdentityPermissions.NotificationRead, IdentityPermissions.TemplateRead,
-            IdentityPermissions.CampaignRead, IdentityPermissions.MemberRead, IdentityPermissions.OrganizationRead
-        ], ct);
-        await EnsureRoleAsync(db, IdentityRoles.Auditor, "Organization", true,
-        [
-            IdentityPermissions.NotificationRead, IdentityPermissions.TemplateRead,
-            IdentityPermissions.CampaignRead, IdentityPermissions.AuditRead, IdentityPermissions.OrganizationRead
-        ], ct);
+        await EnsureRoleAsync(
+            db,
+            IdentityRoles.OrganizationAdmin,
+            "Organization",
+            true,
+            [
+                IdentityPermissions.NotificationRead,
+                IdentityPermissions.NotificationSend,
+                IdentityPermissions.TemplateRead,
+                IdentityPermissions.TemplateWrite,
+                IdentityPermissions.TemplateDelete,
+                IdentityPermissions.CampaignRead,
+                IdentityPermissions.CampaignCreate,
+                IdentityPermissions.CampaignStart,
+                IdentityPermissions.CampaignCancel,
+                IdentityPermissions.MemberInvite,
+                IdentityPermissions.MemberRoleAssign,
+                IdentityPermissions.MemberSuspend,
+                IdentityPermissions.MemberRead,
+                IdentityPermissions.OrganizationRead,
+                IdentityPermissions.OrganizationUpdate,
+                IdentityPermissions.AuditRead
+            ],
+            ct);
+        await EnsureRoleAsync(
+            db,
+            IdentityRoles.NotificationOperator,
+            "Organization",
+            true,
+            [
+                IdentityPermissions.NotificationRead,
+                IdentityPermissions.NotificationSend,
+                IdentityPermissions.TemplateRead,
+                IdentityPermissions.TemplateWrite,
+                IdentityPermissions.CampaignRead,
+                IdentityPermissions.CampaignCreate,
+                IdentityPermissions.CampaignStart
+            ],
+            ct);
+        await EnsureRoleAsync(
+            db,
+            IdentityRoles.Viewer,
+            "Organization",
+            true,
+            [
+                IdentityPermissions.NotificationRead,
+                IdentityPermissions.TemplateRead,
+                IdentityPermissions.CampaignRead,
+                IdentityPermissions.MemberRead,
+                IdentityPermissions.OrganizationRead
+            ],
+            ct);
+        await EnsureRoleAsync(
+            db,
+            IdentityRoles.Auditor,
+            "Organization",
+            true,
+            [
+                IdentityPermissions.NotificationRead,
+                IdentityPermissions.TemplateRead,
+                IdentityPermissions.CampaignRead,
+                IdentityPermissions.AuditRead,
+                IdentityPermissions.OrganizationRead
+            ],
+            ct);
 
         log?.LogInformation("Identity roles/permissions seeded");
     }
 
     static async Task EnsureRoleAsync(
-        NotificationDbContext db, string name, string scope, bool system,
-        IReadOnlyList<string> permissionNames, CancellationToken ct)
+        NotificationDbContext db,
+        string name,
+        string scope,
+        bool system,
+        IReadOnlyList<string> permissionNames,
+        CancellationToken ct)
     {
-        var role = await db.IdentityRoles.FirstOrDefaultAsync(r => r.Name == name, ct);
+        var role = await db.Set<IdentityRoleEntity>().FirstOrDefaultAsync(r => r.Name == name, ct);
         if (role is null)
         {
             role = new IdentityRoleEntity { Name = name, Scope = scope, IsSystem = system };
-            db.IdentityRoles.Add(role);
+            db.Set<IdentityRoleEntity>().Add(role);
             await db.SaveChangesAsync(ct);
         }
 
-        var perms = await db.IdentityPermissions.Where(p => permissionNames.Contains(p.Name)).ToListAsync(ct);
+        var perms = await db.Set<IdentityPermissionEntity>()
+            .Where(p => permissionNames.Contains(p.Name))
+            .ToListAsync(ct);
         foreach (var p in perms)
         {
-            if (await db.RolePermissions.AnyAsync(rp => rp.RoleId == role.Id && rp.PermissionId == p.Id, ct))
+            if (await db.Set<RolePermissionEntity>().AnyAsync(rp => rp.RoleId == role.Id && rp.PermissionId == p.Id, ct))
                 continue;
-            db.RolePermissions.Add(new RolePermissionEntity { RoleId = role.Id, PermissionId = p.Id });
+            db.Set<RolePermissionEntity>().Add(new RolePermissionEntity { RoleId = role.Id, PermissionId = p.Id });
         }
+
         await db.SaveChangesAsync(ct);
     }
 }

--- a/src/BuildingBlocks/NotificationHub.Core/Identity/IdentitySchema.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Identity/IdentitySchema.cs
@@ -1,0 +1,173 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NotificationHub.Core.Persistence;
+
+namespace NotificationHub.Core.Identity;
+
+/// <summary>Ensures identity tables + seeds system roles/permissions (Phase-style, no breaking API keys).</summary>
+public static class IdentitySchema
+{
+    public static async Task EnsureAsync(NotificationDbContext db, ILogger? log = null, CancellationToken ct = default)
+    {
+        await db.Database.ExecuteSqlRawAsync("""
+            CREATE TABLE IF NOT EXISTS identity_organizations (
+                "Id" uuid PRIMARY KEY,
+                "Name" varchar(256) NOT NULL,
+                "Slug" varchar(128),
+                "Type" varchar(64) NOT NULL DEFAULT 'Merchant',
+                "Status" varchar(32) NOT NULL DEFAULT 'Active',
+                "CreatedAt" timestamptz NOT NULL,
+                "UpdatedAt" timestamptz NOT NULL
+            );
+            CREATE UNIQUE INDEX IF NOT EXISTS ix_identity_org_slug ON identity_organizations ("Slug") WHERE "Slug" IS NOT NULL;
+
+            CREATE TABLE IF NOT EXISTS identity_users (
+                "Id" uuid PRIMARY KEY,
+                "Email" varchar(320) NOT NULL,
+                "DisplayName" varchar(256),
+                "Phone" varchar(64),
+                "Status" varchar(32) NOT NULL DEFAULT 'Active',
+                "PasswordHash" varchar(512),
+                "CreatedAt" timestamptz NOT NULL,
+                "UpdatedAt" timestamptz NOT NULL
+            );
+            CREATE UNIQUE INDEX IF NOT EXISTS ix_identity_users_email ON identity_users (lower("Email"));
+
+            CREATE TABLE IF NOT EXISTS identity_memberships (
+                "Id" uuid PRIMARY KEY,
+                "OrganizationId" uuid NOT NULL REFERENCES identity_organizations("Id"),
+                "UserId" uuid NOT NULL REFERENCES identity_users("Id"),
+                "Status" varchar(32) NOT NULL DEFAULT 'Invited',
+                "JoinedAt" timestamptz NOT NULL,
+                "RevokedAt" timestamptz
+            );
+            CREATE UNIQUE INDEX IF NOT EXISTS ix_identity_membership_org_user
+                ON identity_memberships ("OrganizationId", "UserId");
+            CREATE INDEX IF NOT EXISTS ix_identity_membership_user ON identity_memberships ("UserId");
+
+            CREATE TABLE IF NOT EXISTS identity_roles (
+                "Id" uuid PRIMARY KEY,
+                "Name" varchar(128) NOT NULL,
+                "Scope" varchar(32) NOT NULL DEFAULT 'Organization',
+                "Description" varchar(512),
+                "IsSystem" boolean NOT NULL DEFAULT false
+            );
+            CREATE UNIQUE INDEX IF NOT EXISTS ix_identity_roles_name ON identity_roles ("Name");
+
+            CREATE TABLE IF NOT EXISTS identity_permissions (
+                "Id" uuid PRIMARY KEY,
+                "Name" varchar(128) NOT NULL,
+                "Description" varchar(512)
+            );
+            CREATE UNIQUE INDEX IF NOT EXISTS ix_identity_permissions_name ON identity_permissions ("Name");
+
+            CREATE TABLE IF NOT EXISTS identity_role_permissions (
+                "RoleId" uuid NOT NULL REFERENCES identity_roles("Id"),
+                "PermissionId" uuid NOT NULL REFERENCES identity_permissions("Id"),
+                PRIMARY KEY ("RoleId", "PermissionId")
+            );
+
+            CREATE TABLE IF NOT EXISTS identity_membership_roles (
+                "MembershipId" uuid NOT NULL REFERENCES identity_memberships("Id"),
+                "RoleId" uuid NOT NULL REFERENCES identity_roles("Id"),
+                PRIMARY KEY ("MembershipId", "RoleId")
+            );
+
+            CREATE TABLE IF NOT EXISTS identity_invitations (
+                "Id" uuid PRIMARY KEY,
+                "OrganizationId" uuid NOT NULL REFERENCES identity_organizations("Id"),
+                "Email" varchar(320) NOT NULL,
+                "TokenHash" varchar(128) NOT NULL,
+                "InvitedByUserId" uuid,
+                "RoleName" varchar(128),
+                "ExpiresAt" timestamptz NOT NULL,
+                "AcceptedAt" timestamptz,
+                "CreatedAt" timestamptz NOT NULL
+            );
+            CREATE UNIQUE INDEX IF NOT EXISTS ix_identity_invitations_token ON identity_invitations ("TokenHash");
+
+            CREATE TABLE IF NOT EXISTS identity_sessions (
+                "Id" uuid PRIMARY KEY,
+                "UserId" uuid NOT NULL REFERENCES identity_users("Id"),
+                "OrganizationId" uuid,
+                "ClientId" varchar(128),
+                "JwtId" varchar(128),
+                "RefreshTokenHash" varchar(128),
+                "Ip" varchar(64),
+                "UserAgent" varchar(512),
+                "CreatedAt" timestamptz NOT NULL,
+                "LastSeenAt" timestamptz NOT NULL,
+                "ExpiresAt" timestamptz NOT NULL,
+                "RevokedAt" timestamptz,
+                "IsActive" boolean NOT NULL DEFAULT true
+            );
+            CREATE INDEX IF NOT EXISTS ix_identity_sessions_user ON identity_sessions ("UserId") WHERE "IsActive" = true;
+            """, ct);
+
+        await SeedAsync(db, log, ct);
+        log?.LogInformation("Identity schema ensured");
+    }
+
+    static async Task SeedAsync(NotificationDbContext db, ILogger? log, CancellationToken ct)
+    {
+        foreach (var name in IdentityPermissions.All)
+        {
+            if (await db.IdentityPermissions.AnyAsync(p => p.Name == name, ct))
+                continue;
+            db.IdentityPermissions.Add(new IdentityPermissionEntity { Name = name });
+        }
+        await db.SaveChangesAsync(ct);
+
+        await EnsureRoleAsync(db, IdentityRoles.PlatformAdmin, "Platform", true, IdentityPermissions.All, ct);
+        await EnsureRoleAsync(db, IdentityRoles.OrganizationOwner, "Organization", true, IdentityPermissions.All, ct);
+        await EnsureRoleAsync(db, IdentityRoles.OrganizationAdmin, "Organization", true,
+        [
+            IdentityPermissions.NotificationRead, IdentityPermissions.NotificationSend,
+            IdentityPermissions.TemplateRead, IdentityPermissions.TemplateWrite, IdentityPermissions.TemplateDelete,
+            IdentityPermissions.CampaignRead, IdentityPermissions.CampaignCreate, IdentityPermissions.CampaignStart, IdentityPermissions.CampaignCancel,
+            IdentityPermissions.MemberInvite, IdentityPermissions.MemberRoleAssign, IdentityPermissions.MemberSuspend, IdentityPermissions.MemberRead,
+            IdentityPermissions.OrganizationRead, IdentityPermissions.OrganizationUpdate,
+            IdentityPermissions.AuditRead
+        ], ct);
+        await EnsureRoleAsync(db, IdentityRoles.NotificationOperator, "Organization", true,
+        [
+            IdentityPermissions.NotificationRead, IdentityPermissions.NotificationSend,
+            IdentityPermissions.TemplateRead, IdentityPermissions.TemplateWrite,
+            IdentityPermissions.CampaignRead, IdentityPermissions.CampaignCreate, IdentityPermissions.CampaignStart
+        ], ct);
+        await EnsureRoleAsync(db, IdentityRoles.Viewer, "Organization", true,
+        [
+            IdentityPermissions.NotificationRead, IdentityPermissions.TemplateRead,
+            IdentityPermissions.CampaignRead, IdentityPermissions.MemberRead, IdentityPermissions.OrganizationRead
+        ], ct);
+        await EnsureRoleAsync(db, IdentityRoles.Auditor, "Organization", true,
+        [
+            IdentityPermissions.NotificationRead, IdentityPermissions.TemplateRead,
+            IdentityPermissions.CampaignRead, IdentityPermissions.AuditRead, IdentityPermissions.OrganizationRead
+        ], ct);
+
+        log?.LogInformation("Identity roles/permissions seeded");
+    }
+
+    static async Task EnsureRoleAsync(
+        NotificationDbContext db, string name, string scope, bool system,
+        IReadOnlyList<string> permissionNames, CancellationToken ct)
+    {
+        var role = await db.IdentityRoles.FirstOrDefaultAsync(r => r.Name == name, ct);
+        if (role is null)
+        {
+            role = new IdentityRoleEntity { Name = name, Scope = scope, IsSystem = system };
+            db.IdentityRoles.Add(role);
+            await db.SaveChangesAsync(ct);
+        }
+
+        var perms = await db.IdentityPermissions.Where(p => permissionNames.Contains(p.Name)).ToListAsync(ct);
+        foreach (var p in perms)
+        {
+            if (await db.RolePermissions.AnyAsync(rp => rp.RoleId == role.Id && rp.PermissionId == p.Id, ct))
+                continue;
+            db.RolePermissions.Add(new RolePermissionEntity { RoleId = role.Id, PermissionId = p.Id });
+        }
+        await db.SaveChangesAsync(ct);
+    }
+}

--- a/src/BuildingBlocks/NotificationHub.Core/Identity/MembershipService.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Identity/MembershipService.cs
@@ -10,32 +10,32 @@ public sealed class MembershipService(NotificationDbContext db, ILogger<Membersh
 {
     public async Task<MembershipSnapshot?> GetActiveMembershipAsync(Guid userId, Guid organizationId, CancellationToken ct = default)
     {
-        var mem = await db.OrganizationMemberships.AsNoTracking()
+        var mem = await db.Set<OrganizationMembershipEntity>().AsNoTracking()
             .FirstOrDefaultAsync(m => m.UserId == userId && m.OrganizationId == organizationId, ct);
         if (mem is null || !string.Equals(mem.Status, "Active", StringComparison.OrdinalIgnoreCase))
             return null;
 
-        var org = await db.Organizations.AsNoTracking().FirstOrDefaultAsync(o => o.Id == organizationId, ct);
+        var org = await db.Set<OrganizationEntity>().AsNoTracking().FirstOrDefaultAsync(o => o.Id == organizationId, ct);
         if (org is null || !string.Equals(org.Status, "Active", StringComparison.OrdinalIgnoreCase))
             return null;
 
-        var roleIds = await db.MembershipRoles.AsNoTracking()
+        var roleIds = await db.Set<MembershipRoleEntity>().AsNoTracking()
             .Where(mr => mr.MembershipId == mem.Id)
             .Select(mr => mr.RoleId)
             .ToListAsync(ct);
 
-        var roles = await db.IdentityRoles.AsNoTracking()
+        var roles = await db.Set<IdentityRoleEntity>().AsNoTracking()
             .Where(r => roleIds.Contains(r.Id))
             .Select(r => r.Name)
             .ToListAsync(ct);
 
-        var permIds = await db.RolePermissions.AsNoTracking()
+        var permIds = await db.Set<RolePermissionEntity>().AsNoTracking()
             .Where(rp => roleIds.Contains(rp.RoleId))
             .Select(rp => rp.PermissionId)
             .Distinct()
             .ToListAsync(ct);
 
-        var permissions = await db.IdentityPermissions.AsNoTracking()
+        var permissions = await db.Set<IdentityPermissionEntity>().AsNoTracking()
             .Where(p => permIds.Contains(p.Id))
             .Select(p => p.Name)
             .ToListAsync(ct);
@@ -46,8 +46,8 @@ public sealed class MembershipService(NotificationDbContext db, ILogger<Membersh
     public async Task<IReadOnlyList<OrganizationMembershipDto>> ListMembershipsAsync(Guid userId, CancellationToken ct = default)
     {
         var q =
-            from m in db.OrganizationMemberships.AsNoTracking()
-            join o in db.Organizations.AsNoTracking() on m.OrganizationId equals o.Id
+            from m in db.Set<OrganizationMembershipEntity>().AsNoTracking()
+            join o in db.Set<OrganizationEntity>().AsNoTracking() on m.OrganizationId equals o.Id
             where m.UserId == userId && m.Status != "Revoked"
             select new { m, o };
 
@@ -55,33 +55,35 @@ public sealed class MembershipService(NotificationDbContext db, ILogger<Membersh
         var result = new List<OrganizationMembershipDto>();
         foreach (var row in rows)
         {
-            var roleIds = await db.MembershipRoles.AsNoTracking()
+            var roleIds = await db.Set<MembershipRoleEntity>().AsNoTracking()
                 .Where(mr => mr.MembershipId == row.m.Id).Select(mr => mr.RoleId).ToListAsync(ct);
-            var roles = await db.IdentityRoles.AsNoTracking()
+            var roles = await db.Set<IdentityRoleEntity>().AsNoTracking()
                 .Where(r => roleIds.Contains(r.Id)).Select(r => r.Name).ToListAsync(ct);
             result.Add(new OrganizationMembershipDto(
                 row.m.Id, row.o.Id, row.o.Name, row.o.Status, row.m.Status, roles));
         }
+
         return result;
     }
 
     public async Task<AuthMeDto?> GetMeAsync(Guid userId, Guid? organizationId, CancellationToken ct = default)
     {
-        var user = await db.IdentityUsers.AsNoTracking().FirstOrDefaultAsync(u => u.Id == userId, ct);
-        if (user is null || string.Equals(user.Status, "Disabled", StringComparison.OrdinalIgnoreCase)
+        var user = await db.Set<IdentityUserEntity>().AsNoTracking().FirstOrDefaultAsync(u => u.Id == userId, ct);
+        if (user is null
+            || string.Equals(user.Status, "Disabled", StringComparison.OrdinalIgnoreCase)
             || string.Equals(user.Status, "Deleted", StringComparison.OrdinalIgnoreCase))
+        {
             return null;
+        }
 
         if (organizationId is null)
-        {
             return new AuthMeDto(user.Id, user.Email, user.DisplayName, null, null, null, [], []);
-        }
 
         var snap = await GetActiveMembershipAsync(userId, organizationId.Value, ct);
         if (snap is null)
             return new AuthMeDto(user.Id, user.Email, user.DisplayName, null, null, null, [], []);
 
-        var org = await db.Organizations.AsNoTracking().FirstAsync(o => o.Id == organizationId.Value, ct);
+        var org = await db.Set<OrganizationEntity>().AsNoTracking().FirstAsync(o => o.Id == organizationId.Value, ct);
         return new AuthMeDto(
             user.Id, user.Email, user.DisplayName,
             org.Id, org.Name, snap.MembershipId,
@@ -95,7 +97,7 @@ public sealed class MembershipService(NotificationDbContext db, ILogger<Membersh
         if (string.IsNullOrWhiteSpace(email))
             return new InviteResult(false, null, "invalid_email");
 
-        var org = await db.Organizations.AsNoTracking().FirstOrDefaultAsync(o => o.Id == organizationId, ct);
+        var org = await db.Set<OrganizationEntity>().AsNoTracking().FirstOrDefaultAsync(o => o.Id == organizationId, ct);
         if (org is null || !string.Equals(org.Status, "Active", StringComparison.OrdinalIgnoreCase))
             return new InviteResult(false, null, "organization_inactive");
 
@@ -110,32 +112,30 @@ public sealed class MembershipService(NotificationDbContext db, ILogger<Membersh
             RoleName = roleName ?? IdentityRoles.Viewer,
             ExpiresAt = DateTimeOffset.UtcNow.AddDays(7)
         };
-        db.Invitations.Add(inv);
+        db.Set<InvitationEntity>().Add(inv);
         await db.SaveChangesAsync(ct);
 
-        // Raw token returned only once via out-of-band channel in production; stored hashed.
         log.LogInformation("Invitation created {InvitationId} for org {OrgId}", inv.Id, organizationId);
         await RecordSecurityEventAsync("UserInvited", invitedByUserId, organizationId, email, ct);
 
-        // For API response in Sprint 2 we return id only (token delivery via email later).
         return new InviteResult(true, inv.Id, null);
     }
 
     public async Task<bool> AcceptInviteAsync(string rawToken, Guid userId, CancellationToken ct = default)
     {
         var hash = HashToken(rawToken);
-        var inv = await db.Invitations.FirstOrDefaultAsync(i => i.TokenHash == hash, ct);
+        var inv = await db.Set<InvitationEntity>().FirstOrDefaultAsync(i => i.TokenHash == hash, ct);
         if (inv is null || inv.AcceptedAt is not null || inv.ExpiresAt < DateTimeOffset.UtcNow)
             return false;
 
-        var user = await db.IdentityUsers.FirstOrDefaultAsync(u => u.Id == userId, ct);
+        var user = await db.Set<IdentityUserEntity>().FirstOrDefaultAsync(u => u.Id == userId, ct);
         if (user is null)
             return false;
 
         if (!string.Equals(user.Email, inv.Email, StringComparison.OrdinalIgnoreCase))
             return false;
 
-        var existing = await db.OrganizationMemberships
+        var existing = await db.Set<OrganizationMembershipEntity>()
             .FirstOrDefaultAsync(m => m.UserId == userId && m.OrganizationId == inv.OrganizationId, ct);
 
         OrganizationMembershipEntity mem;
@@ -148,7 +148,7 @@ public sealed class MembershipService(NotificationDbContext db, ILogger<Membersh
                 Status = "Active",
                 JoinedAt = DateTimeOffset.UtcNow
             };
-            db.OrganizationMemberships.Add(mem);
+            db.Set<OrganizationMembershipEntity>().Add(mem);
             await db.SaveChangesAsync(ct);
         }
         else
@@ -160,11 +160,11 @@ public sealed class MembershipService(NotificationDbContext db, ILogger<Membersh
 
         if (!string.IsNullOrWhiteSpace(inv.RoleName))
         {
-            var role = await db.IdentityRoles.FirstOrDefaultAsync(r => r.Name == inv.RoleName, ct);
+            var role = await db.Set<IdentityRoleEntity>().FirstOrDefaultAsync(r => r.Name == inv.RoleName, ct);
             if (role is not null &&
-                !await db.MembershipRoles.AnyAsync(mr => mr.MembershipId == mem.Id && mr.RoleId == role.Id, ct))
+                !await db.Set<MembershipRoleEntity>().AnyAsync(mr => mr.MembershipId == mem.Id && mr.RoleId == role.Id, ct))
             {
-                db.MembershipRoles.Add(new MembershipRoleEntity { MembershipId = mem.Id, RoleId = role.Id });
+                db.Set<MembershipRoleEntity>().Add(new MembershipRoleEntity { MembershipId = mem.Id, RoleId = role.Id });
             }
         }
 
@@ -176,7 +176,7 @@ public sealed class MembershipService(NotificationDbContext db, ILogger<Membersh
 
     public async Task RevokeSessionAsync(Guid userId, Guid? sessionId, string? jwtId, CancellationToken ct = default)
     {
-        IQueryable<UserSessionEntity> q = db.UserSessions.Where(s => s.UserId == userId && s.IsActive);
+        IQueryable<UserSessionEntity> q = db.Set<UserSessionEntity>().Where(s => s.UserId == userId && s.IsActive);
         if (sessionId is not null)
             q = q.Where(s => s.Id == sessionId);
         else if (!string.IsNullOrEmpty(jwtId))
@@ -188,6 +188,7 @@ public sealed class MembershipService(NotificationDbContext db, ILogger<Membersh
             s.IsActive = false;
             s.RevokedAt = DateTimeOffset.UtcNow;
         }
+
         await db.SaveChangesAsync(ct);
         await RecordSecurityEventAsync("SessionRevoked", userId, null, sessionId?.ToString() ?? jwtId, ct);
     }

--- a/src/BuildingBlocks/NotificationHub.Core/Identity/MembershipService.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Identity/MembershipService.cs
@@ -1,0 +1,214 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NotificationHub.Core.Persistence;
+
+namespace NotificationHub.Core.Identity;
+
+public sealed class MembershipService(NotificationDbContext db, ILogger<MembershipService> log) : IMembershipService
+{
+    public async Task<MembershipSnapshot?> GetActiveMembershipAsync(Guid userId, Guid organizationId, CancellationToken ct = default)
+    {
+        var mem = await db.OrganizationMemberships.AsNoTracking()
+            .FirstOrDefaultAsync(m => m.UserId == userId && m.OrganizationId == organizationId, ct);
+        if (mem is null || !string.Equals(mem.Status, "Active", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var org = await db.Organizations.AsNoTracking().FirstOrDefaultAsync(o => o.Id == organizationId, ct);
+        if (org is null || !string.Equals(org.Status, "Active", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var roleIds = await db.MembershipRoles.AsNoTracking()
+            .Where(mr => mr.MembershipId == mem.Id)
+            .Select(mr => mr.RoleId)
+            .ToListAsync(ct);
+
+        var roles = await db.IdentityRoles.AsNoTracking()
+            .Where(r => roleIds.Contains(r.Id))
+            .Select(r => r.Name)
+            .ToListAsync(ct);
+
+        var permIds = await db.RolePermissions.AsNoTracking()
+            .Where(rp => roleIds.Contains(rp.RoleId))
+            .Select(rp => rp.PermissionId)
+            .Distinct()
+            .ToListAsync(ct);
+
+        var permissions = await db.IdentityPermissions.AsNoTracking()
+            .Where(p => permIds.Contains(p.Id))
+            .Select(p => p.Name)
+            .ToListAsync(ct);
+
+        return new MembershipSnapshot(mem.Id, organizationId, userId, mem.Status, roles, permissions);
+    }
+
+    public async Task<IReadOnlyList<OrganizationMembershipDto>> ListMembershipsAsync(Guid userId, CancellationToken ct = default)
+    {
+        var q =
+            from m in db.OrganizationMemberships.AsNoTracking()
+            join o in db.Organizations.AsNoTracking() on m.OrganizationId equals o.Id
+            where m.UserId == userId && m.Status != "Revoked"
+            select new { m, o };
+
+        var rows = await q.ToListAsync(ct);
+        var result = new List<OrganizationMembershipDto>();
+        foreach (var row in rows)
+        {
+            var roleIds = await db.MembershipRoles.AsNoTracking()
+                .Where(mr => mr.MembershipId == row.m.Id).Select(mr => mr.RoleId).ToListAsync(ct);
+            var roles = await db.IdentityRoles.AsNoTracking()
+                .Where(r => roleIds.Contains(r.Id)).Select(r => r.Name).ToListAsync(ct);
+            result.Add(new OrganizationMembershipDto(
+                row.m.Id, row.o.Id, row.o.Name, row.o.Status, row.m.Status, roles));
+        }
+        return result;
+    }
+
+    public async Task<AuthMeDto?> GetMeAsync(Guid userId, Guid? organizationId, CancellationToken ct = default)
+    {
+        var user = await db.IdentityUsers.AsNoTracking().FirstOrDefaultAsync(u => u.Id == userId, ct);
+        if (user is null || string.Equals(user.Status, "Disabled", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(user.Status, "Deleted", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        if (organizationId is null)
+        {
+            return new AuthMeDto(user.Id, user.Email, user.DisplayName, null, null, null, [], []);
+        }
+
+        var snap = await GetActiveMembershipAsync(userId, organizationId.Value, ct);
+        if (snap is null)
+            return new AuthMeDto(user.Id, user.Email, user.DisplayName, null, null, null, [], []);
+
+        var org = await db.Organizations.AsNoTracking().FirstAsync(o => o.Id == organizationId.Value, ct);
+        return new AuthMeDto(
+            user.Id, user.Email, user.DisplayName,
+            org.Id, org.Name, snap.MembershipId,
+            snap.Roles, snap.Permissions);
+    }
+
+    public async Task<InviteResult> InviteAsync(
+        Guid organizationId, string email, string? roleName, Guid invitedByUserId, CancellationToken ct = default)
+    {
+        email = email.Trim().ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(email))
+            return new InviteResult(false, null, "invalid_email");
+
+        var org = await db.Organizations.AsNoTracking().FirstOrDefaultAsync(o => o.Id == organizationId, ct);
+        if (org is null || !string.Equals(org.Status, "Active", StringComparison.OrdinalIgnoreCase))
+            return new InviteResult(false, null, "organization_inactive");
+
+        var raw = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+        var hash = HashToken(raw);
+        var inv = new InvitationEntity
+        {
+            OrganizationId = organizationId,
+            Email = email,
+            TokenHash = hash,
+            InvitedByUserId = invitedByUserId,
+            RoleName = roleName ?? IdentityRoles.Viewer,
+            ExpiresAt = DateTimeOffset.UtcNow.AddDays(7)
+        };
+        db.Invitations.Add(inv);
+        await db.SaveChangesAsync(ct);
+
+        // Raw token returned only once via out-of-band channel in production; stored hashed.
+        log.LogInformation("Invitation created {InvitationId} for org {OrgId}", inv.Id, organizationId);
+        await RecordSecurityEventAsync("UserInvited", invitedByUserId, organizationId, email, ct);
+
+        // For API response in Sprint 2 we return id only (token delivery via email later).
+        return new InviteResult(true, inv.Id, null);
+    }
+
+    public async Task<bool> AcceptInviteAsync(string rawToken, Guid userId, CancellationToken ct = default)
+    {
+        var hash = HashToken(rawToken);
+        var inv = await db.Invitations.FirstOrDefaultAsync(i => i.TokenHash == hash, ct);
+        if (inv is null || inv.AcceptedAt is not null || inv.ExpiresAt < DateTimeOffset.UtcNow)
+            return false;
+
+        var user = await db.IdentityUsers.FirstOrDefaultAsync(u => u.Id == userId, ct);
+        if (user is null)
+            return false;
+
+        if (!string.Equals(user.Email, inv.Email, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var existing = await db.OrganizationMemberships
+            .FirstOrDefaultAsync(m => m.UserId == userId && m.OrganizationId == inv.OrganizationId, ct);
+
+        OrganizationMembershipEntity mem;
+        if (existing is null)
+        {
+            mem = new OrganizationMembershipEntity
+            {
+                OrganizationId = inv.OrganizationId,
+                UserId = userId,
+                Status = "Active",
+                JoinedAt = DateTimeOffset.UtcNow
+            };
+            db.OrganizationMemberships.Add(mem);
+            await db.SaveChangesAsync(ct);
+        }
+        else
+        {
+            mem = existing;
+            mem.Status = "Active";
+            mem.RevokedAt = null;
+        }
+
+        if (!string.IsNullOrWhiteSpace(inv.RoleName))
+        {
+            var role = await db.IdentityRoles.FirstOrDefaultAsync(r => r.Name == inv.RoleName, ct);
+            if (role is not null &&
+                !await db.MembershipRoles.AnyAsync(mr => mr.MembershipId == mem.Id && mr.RoleId == role.Id, ct))
+            {
+                db.MembershipRoles.Add(new MembershipRoleEntity { MembershipId = mem.Id, RoleId = role.Id });
+            }
+        }
+
+        inv.AcceptedAt = DateTimeOffset.UtcNow;
+        await db.SaveChangesAsync(ct);
+        await RecordSecurityEventAsync("UserActivated", userId, inv.OrganizationId, null, ct);
+        return true;
+    }
+
+    public async Task RevokeSessionAsync(Guid userId, Guid? sessionId, string? jwtId, CancellationToken ct = default)
+    {
+        IQueryable<UserSessionEntity> q = db.UserSessions.Where(s => s.UserId == userId && s.IsActive);
+        if (sessionId is not null)
+            q = q.Where(s => s.Id == sessionId);
+        else if (!string.IsNullOrEmpty(jwtId))
+            q = q.Where(s => s.JwtId == jwtId);
+
+        var sessions = await q.ToListAsync(ct);
+        foreach (var s in sessions)
+        {
+            s.IsActive = false;
+            s.RevokedAt = DateTimeOffset.UtcNow;
+        }
+        await db.SaveChangesAsync(ct);
+        await RecordSecurityEventAsync("SessionRevoked", userId, null, sessionId?.ToString() ?? jwtId, ct);
+    }
+
+    public async Task RecordSecurityEventAsync(
+        string action, Guid? userId, Guid? organizationId, string? details, CancellationToken ct = default)
+    {
+        db.AuditEntries.Add(new AuditEntryEntity
+        {
+            Action = action,
+            TenantId = organizationId?.ToString(),
+            Actor = userId?.ToString(),
+            Details = details is { Length: > 500 } ? details[..500] : details,
+            CreatedAt = DateTimeOffset.UtcNow
+        });
+        await db.SaveChangesAsync(ct);
+    }
+
+    static string HashToken(string raw)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(raw));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+}

--- a/src/BuildingBlocks/NotificationHub.Core/Identity/OrganizationAdminService.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Identity/OrganizationAdminService.cs
@@ -1,0 +1,111 @@
+using Microsoft.EntityFrameworkCore;
+using NotificationHub.Core.Persistence;
+
+namespace NotificationHub.Core.Identity;
+
+public sealed class OrganizationAdminService(NotificationDbContext db) : IOrganizationAdminService
+{
+    public async Task<OrganizationDto?> GetAsync(Guid organizationId, CancellationToken ct = default)
+    {
+        var o = await db.Organizations.AsNoTracking().FirstOrDefaultAsync(x => x.Id == organizationId, ct);
+        return o is null ? null : new OrganizationDto(o.Id, o.Name, o.Slug, o.Type, o.Status);
+    }
+
+    public async Task<OrganizationDto> CreateAsync(string name, string? slug, string type, CancellationToken ct = default)
+    {
+        var o = new OrganizationEntity
+        {
+            Name = name.Trim(),
+            Slug = string.IsNullOrWhiteSpace(slug) ? null : slug.Trim().ToLowerInvariant(),
+            Type = string.IsNullOrWhiteSpace(type) ? "Merchant" : type,
+            Status = "Active"
+        };
+        db.Organizations.Add(o);
+        await db.SaveChangesAsync(ct);
+        return new OrganizationDto(o.Id, o.Name, o.Slug, o.Type, o.Status);
+    }
+
+    public async Task<OrganizationDto?> UpdateAsync(Guid organizationId, string? name, string? status, CancellationToken ct = default)
+    {
+        var o = await db.Organizations.FirstOrDefaultAsync(x => x.Id == organizationId, ct);
+        if (o is null) return null;
+        if (!string.IsNullOrWhiteSpace(name)) o.Name = name.Trim();
+        if (!string.IsNullOrWhiteSpace(status)) o.Status = status;
+        o.UpdatedAt = DateTimeOffset.UtcNow;
+        await db.SaveChangesAsync(ct);
+        return new OrganizationDto(o.Id, o.Name, o.Slug, o.Type, o.Status);
+    }
+
+    public async Task<IReadOnlyList<MemberDto>> ListMembersAsync(Guid organizationId, CancellationToken ct = default)
+    {
+        var rows = await (
+            from m in db.OrganizationMemberships.AsNoTracking()
+            join u in db.IdentityUsers.AsNoTracking() on m.UserId equals u.Id
+            where m.OrganizationId == organizationId && m.Status != "Revoked"
+            select new { m, u }).ToListAsync(ct);
+
+        var list = new List<MemberDto>();
+        foreach (var row in rows)
+        {
+            var roleIds = await db.MembershipRoles.AsNoTracking()
+                .Where(mr => mr.MembershipId == row.m.Id).Select(mr => mr.RoleId).ToListAsync(ct);
+            var roles = await db.IdentityRoles.AsNoTracking()
+                .Where(r => roleIds.Contains(r.Id)).Select(r => r.Name).ToListAsync(ct);
+            list.Add(new MemberDto(row.m.Id, row.u.Id, row.u.Email, row.u.DisplayName, row.m.Status, roles));
+        }
+        return list;
+    }
+
+    public async Task<bool> AssignRoleAsync(Guid membershipId, string roleName, CancellationToken ct = default)
+    {
+        var mem = await db.OrganizationMemberships.FirstOrDefaultAsync(m => m.Id == membershipId, ct);
+        if (mem is null) return false;
+
+        var role = await db.IdentityRoles.FirstOrDefaultAsync(r => r.Name == roleName, ct);
+        if (role is null) return false;
+
+        // Org-scoped roles only via this API — PlatformAdmin cannot be assigned here.
+        if (string.Equals(role.Scope, "Platform", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (await db.MembershipRoles.AnyAsync(mr => mr.MembershipId == membershipId && mr.RoleId == role.Id, ct))
+            return true;
+
+        db.MembershipRoles.Add(new MembershipRoleEntity { MembershipId = membershipId, RoleId = role.Id });
+        await db.SaveChangesAsync(ct);
+        return true;
+    }
+
+    public async Task<bool> RemoveRoleAsync(Guid membershipId, string roleName, CancellationToken ct = default)
+    {
+        var role = await db.IdentityRoles.FirstOrDefaultAsync(r => r.Name == roleName, ct);
+        if (role is null) return false;
+
+        var link = await db.MembershipRoles
+            .FirstOrDefaultAsync(mr => mr.MembershipId == membershipId && mr.RoleId == role.Id, ct);
+        if (link is null) return true;
+
+        db.MembershipRoles.Remove(link);
+        await db.SaveChangesAsync(ct);
+        return true;
+    }
+
+    public async Task<bool> SetMembershipStatusAsync(Guid membershipId, string status, CancellationToken ct = default)
+    {
+        var allowed = new[] { "Active", "Suspended", "Revoked" };
+        if (!allowed.Contains(status, StringComparer.OrdinalIgnoreCase))
+            return false;
+
+        var mem = await db.OrganizationMemberships.FirstOrDefaultAsync(m => m.Id == membershipId, ct);
+        if (mem is null) return false;
+
+        mem.Status = status;
+        if (string.Equals(status, "Revoked", StringComparison.OrdinalIgnoreCase))
+            mem.RevokedAt = DateTimeOffset.UtcNow;
+        else if (string.Equals(status, "Active", StringComparison.OrdinalIgnoreCase))
+            mem.RevokedAt = null;
+
+        await db.SaveChangesAsync(ct);
+        return true;
+    }
+}

--- a/src/BuildingBlocks/NotificationHub.Core/Identity/OrganizationAdminService.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Identity/OrganizationAdminService.cs
@@ -7,7 +7,7 @@ public sealed class OrganizationAdminService(NotificationDbContext db) : IOrgani
 {
     public async Task<OrganizationDto?> GetAsync(Guid organizationId, CancellationToken ct = default)
     {
-        var o = await db.Organizations.AsNoTracking().FirstOrDefaultAsync(x => x.Id == organizationId, ct);
+        var o = await db.Set<OrganizationEntity>().AsNoTracking().FirstOrDefaultAsync(x => x.Id == organizationId, ct);
         return o is null ? null : new OrganizationDto(o.Id, o.Name, o.Slug, o.Type, o.Status);
     }
 
@@ -20,14 +20,14 @@ public sealed class OrganizationAdminService(NotificationDbContext db) : IOrgani
             Type = string.IsNullOrWhiteSpace(type) ? "Merchant" : type,
             Status = "Active"
         };
-        db.Organizations.Add(o);
+        db.Set<OrganizationEntity>().Add(o);
         await db.SaveChangesAsync(ct);
         return new OrganizationDto(o.Id, o.Name, o.Slug, o.Type, o.Status);
     }
 
     public async Task<OrganizationDto?> UpdateAsync(Guid organizationId, string? name, string? status, CancellationToken ct = default)
     {
-        var o = await db.Organizations.FirstOrDefaultAsync(x => x.Id == organizationId, ct);
+        var o = await db.Set<OrganizationEntity>().FirstOrDefaultAsync(x => x.Id == organizationId, ct);
         if (o is null) return null;
         if (!string.IsNullOrWhiteSpace(name)) o.Name = name.Trim();
         if (!string.IsNullOrWhiteSpace(status)) o.Status = status;
@@ -39,53 +39,53 @@ public sealed class OrganizationAdminService(NotificationDbContext db) : IOrgani
     public async Task<IReadOnlyList<MemberDto>> ListMembersAsync(Guid organizationId, CancellationToken ct = default)
     {
         var rows = await (
-            from m in db.OrganizationMemberships.AsNoTracking()
-            join u in db.IdentityUsers.AsNoTracking() on m.UserId equals u.Id
+            from m in db.Set<OrganizationMembershipEntity>().AsNoTracking()
+            join u in db.Set<IdentityUserEntity>().AsNoTracking() on m.UserId equals u.Id
             where m.OrganizationId == organizationId && m.Status != "Revoked"
             select new { m, u }).ToListAsync(ct);
 
         var list = new List<MemberDto>();
         foreach (var row in rows)
         {
-            var roleIds = await db.MembershipRoles.AsNoTracking()
+            var roleIds = await db.Set<MembershipRoleEntity>().AsNoTracking()
                 .Where(mr => mr.MembershipId == row.m.Id).Select(mr => mr.RoleId).ToListAsync(ct);
-            var roles = await db.IdentityRoles.AsNoTracking()
+            var roles = await db.Set<IdentityRoleEntity>().AsNoTracking()
                 .Where(r => roleIds.Contains(r.Id)).Select(r => r.Name).ToListAsync(ct);
             list.Add(new MemberDto(row.m.Id, row.u.Id, row.u.Email, row.u.DisplayName, row.m.Status, roles));
         }
+
         return list;
     }
 
     public async Task<bool> AssignRoleAsync(Guid membershipId, string roleName, CancellationToken ct = default)
     {
-        var mem = await db.OrganizationMemberships.FirstOrDefaultAsync(m => m.Id == membershipId, ct);
+        var mem = await db.Set<OrganizationMembershipEntity>().FirstOrDefaultAsync(m => m.Id == membershipId, ct);
         if (mem is null) return false;
 
-        var role = await db.IdentityRoles.FirstOrDefaultAsync(r => r.Name == roleName, ct);
+        var role = await db.Set<IdentityRoleEntity>().FirstOrDefaultAsync(r => r.Name == roleName, ct);
         if (role is null) return false;
 
-        // Org-scoped roles only via this API — PlatformAdmin cannot be assigned here.
         if (string.Equals(role.Scope, "Platform", StringComparison.OrdinalIgnoreCase))
             return false;
 
-        if (await db.MembershipRoles.AnyAsync(mr => mr.MembershipId == membershipId && mr.RoleId == role.Id, ct))
+        if (await db.Set<MembershipRoleEntity>().AnyAsync(mr => mr.MembershipId == membershipId && mr.RoleId == role.Id, ct))
             return true;
 
-        db.MembershipRoles.Add(new MembershipRoleEntity { MembershipId = membershipId, RoleId = role.Id });
+        db.Set<MembershipRoleEntity>().Add(new MembershipRoleEntity { MembershipId = membershipId, RoleId = role.Id });
         await db.SaveChangesAsync(ct);
         return true;
     }
 
     public async Task<bool> RemoveRoleAsync(Guid membershipId, string roleName, CancellationToken ct = default)
     {
-        var role = await db.IdentityRoles.FirstOrDefaultAsync(r => r.Name == roleName, ct);
+        var role = await db.Set<IdentityRoleEntity>().FirstOrDefaultAsync(r => r.Name == roleName, ct);
         if (role is null) return false;
 
-        var link = await db.MembershipRoles
+        var link = await db.Set<MembershipRoleEntity>()
             .FirstOrDefaultAsync(mr => mr.MembershipId == membershipId && mr.RoleId == role.Id, ct);
         if (link is null) return true;
 
-        db.MembershipRoles.Remove(link);
+        db.Set<MembershipRoleEntity>().Remove(link);
         await db.SaveChangesAsync(ct);
         return true;
     }
@@ -96,7 +96,7 @@ public sealed class OrganizationAdminService(NotificationDbContext db) : IOrgani
         if (!allowed.Contains(status, StringComparer.OrdinalIgnoreCase))
             return false;
 
-        var mem = await db.OrganizationMemberships.FirstOrDefaultAsync(m => m.Id == membershipId, ct);
+        var mem = await db.Set<OrganizationMembershipEntity>().FirstOrDefaultAsync(m => m.Id == membershipId, ct);
         if (mem is null) return false;
 
         mem.Status = status;

--- a/src/BuildingBlocks/NotificationHub.Core/Identity/OrganizationAdminService.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Identity/OrganizationAdminService.cs
@@ -28,9 +28,21 @@ public sealed class OrganizationAdminService(NotificationDbContext db) : IOrgani
     public async Task<OrganizationDto?> UpdateAsync(Guid organizationId, string? name, string? status, CancellationToken ct = default)
     {
         var o = await db.Set<OrganizationEntity>().FirstOrDefaultAsync(x => x.Id == organizationId, ct);
-        if (o is null) return null;
-        if (!string.IsNullOrWhiteSpace(name)) o.Name = name.Trim();
-        if (!string.IsNullOrWhiteSpace(status)) o.Status = status;
+        if (o is null)
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            o.Name = name.Trim();
+        }
+
+        if (!string.IsNullOrWhiteSpace(status))
+        {
+            o.Status = status;
+        }
+
         o.UpdatedAt = DateTimeOffset.UtcNow;
         await db.SaveChangesAsync(ct);
         return new OrganizationDto(o.Id, o.Name, o.Slug, o.Type, o.Status);
@@ -48,9 +60,13 @@ public sealed class OrganizationAdminService(NotificationDbContext db) : IOrgani
         foreach (var row in rows)
         {
             var roleIds = await db.Set<MembershipRoleEntity>().AsNoTracking()
-                .Where(mr => mr.MembershipId == row.m.Id).Select(mr => mr.RoleId).ToListAsync(ct);
+                .Where(mr => mr.MembershipId == row.m.Id)
+                .Select(mr => mr.RoleId)
+                .ToListAsync(ct);
             var roles = await db.Set<IdentityRoleEntity>().AsNoTracking()
-                .Where(r => roleIds.Contains(r.Id)).Select(r => r.Name).ToListAsync(ct);
+                .Where(r => roleIds.Contains(r.Id))
+                .Select(r => r.Name)
+                .ToListAsync(ct);
             list.Add(new MemberDto(row.m.Id, row.u.Id, row.u.Email, row.u.DisplayName, row.m.Status, roles));
         }
 
@@ -60,16 +76,26 @@ public sealed class OrganizationAdminService(NotificationDbContext db) : IOrgani
     public async Task<bool> AssignRoleAsync(Guid membershipId, string roleName, CancellationToken ct = default)
     {
         var mem = await db.Set<OrganizationMembershipEntity>().FirstOrDefaultAsync(m => m.Id == membershipId, ct);
-        if (mem is null) return false;
+        if (mem is null)
+        {
+            return false;
+        }
 
         var role = await db.Set<IdentityRoleEntity>().FirstOrDefaultAsync(r => r.Name == roleName, ct);
-        if (role is null) return false;
+        if (role is null)
+        {
+            return false;
+        }
 
         if (string.Equals(role.Scope, "Platform", StringComparison.OrdinalIgnoreCase))
+        {
             return false;
+        }
 
         if (await db.Set<MembershipRoleEntity>().AnyAsync(mr => mr.MembershipId == membershipId && mr.RoleId == role.Id, ct))
+        {
             return true;
+        }
 
         db.Set<MembershipRoleEntity>().Add(new MembershipRoleEntity { MembershipId = membershipId, RoleId = role.Id });
         await db.SaveChangesAsync(ct);
@@ -79,11 +105,17 @@ public sealed class OrganizationAdminService(NotificationDbContext db) : IOrgani
     public async Task<bool> RemoveRoleAsync(Guid membershipId, string roleName, CancellationToken ct = default)
     {
         var role = await db.Set<IdentityRoleEntity>().FirstOrDefaultAsync(r => r.Name == roleName, ct);
-        if (role is null) return false;
+        if (role is null)
+        {
+            return false;
+        }
 
         var link = await db.Set<MembershipRoleEntity>()
             .FirstOrDefaultAsync(mr => mr.MembershipId == membershipId && mr.RoleId == role.Id, ct);
-        if (link is null) return true;
+        if (link is null)
+        {
+            return true;
+        }
 
         db.Set<MembershipRoleEntity>().Remove(link);
         await db.SaveChangesAsync(ct);
@@ -94,16 +126,25 @@ public sealed class OrganizationAdminService(NotificationDbContext db) : IOrgani
     {
         var allowed = new[] { "Active", "Suspended", "Revoked" };
         if (!allowed.Contains(status, StringComparer.OrdinalIgnoreCase))
+        {
             return false;
+        }
 
         var mem = await db.Set<OrganizationMembershipEntity>().FirstOrDefaultAsync(m => m.Id == membershipId, ct);
-        if (mem is null) return false;
+        if (mem is null)
+        {
+            return false;
+        }
 
         mem.Status = status;
         if (string.Equals(status, "Revoked", StringComparison.OrdinalIgnoreCase))
+        {
             mem.RevokedAt = DateTimeOffset.UtcNow;
+        }
         else if (string.Equals(status, "Active", StringComparison.OrdinalIgnoreCase))
+        {
             mem.RevokedAt = null;
+        }
 
         await db.SaveChangesAsync(ct);
         return true;

--- a/src/BuildingBlocks/NotificationHub.Core/Identity/PermissionRequirement.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Identity/PermissionRequirement.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace NotificationHub.Core.Identity;
+
+public sealed class PermissionRequirement(string permission) : IAuthorizationRequirement
+{
+    public string Permission { get; } = permission;
+}
+
+/// <summary>Deny-by-default: requires authenticated human + active membership permission (server-side).</summary>
+public sealed class PermissionAuthorizationHandler(
+    IMembershipService memberships) : AuthorizationHandler<PermissionRequirement>
+{
+    protected override async Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        PermissionRequirement requirement)
+    {
+        if (context.User?.Identity?.IsAuthenticated != true)
+            return;
+
+        var sub = context.User.FindFirst("sub")?.Value;
+        var tenant = context.User.FindFirst("tenant_id")?.Value;
+        if (!Guid.TryParse(sub, out var userId) || !Guid.TryParse(tenant, out var orgId))
+            return;
+
+        var snap = await memberships.GetActiveMembershipAsync(userId, orgId);
+        if (snap is null)
+            return;
+
+        if (snap.Roles.Contains(IdentityRoles.PlatformAdmin, StringComparer.OrdinalIgnoreCase))
+        {
+            context.Succeed(requirement);
+            return;
+        }
+
+        if (snap.Permissions.Contains(requirement.Permission, StringComparer.OrdinalIgnoreCase))
+            context.Succeed(requirement);
+    }
+}
+
+public sealed class PermissionPolicyProvider : IAuthorizationPolicyProvider
+{
+    readonly DefaultAuthorizationPolicyProvider _fallback;
+
+    public PermissionPolicyProvider(Microsoft.Extensions.Options.IOptions<AuthorizationOptions> options)
+    {
+        _fallback = new DefaultAuthorizationPolicyProvider(options);
+    }
+
+    public Task<AuthorizationPolicy?> GetPolicyAsync(string policyName)
+    {
+        if (policyName.Contains('.', StringComparison.Ordinal))
+        {
+            var policy = new AuthorizationPolicyBuilder()
+                .AddRequirements(new PermissionRequirement(policyName))
+                .Build();
+            return Task.FromResult<AuthorizationPolicy?>(policy);
+        }
+        return _fallback.GetPolicyAsync(policyName);
+    }
+
+    public Task<AuthorizationPolicy> GetDefaultPolicyAsync() => _fallback.GetDefaultPolicyAsync();
+    public Task<AuthorizationPolicy?> GetFallbackPolicyAsync() => _fallback.GetFallbackPolicyAsync();
+}

--- a/src/BuildingBlocks/NotificationHub.Core/Identity/SessionService.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Identity/SessionService.cs
@@ -1,0 +1,107 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NotificationHub.Core.Persistence;
+
+namespace NotificationHub.Core.Identity;
+
+public sealed class SessionService(NotificationDbContext db, ILogger<SessionService> log) : ISessionService
+{
+    public async Task<IReadOnlyList<SessionDto>> ListAsync(Guid userId, CancellationToken ct = default)
+    {
+        var rows = await db.UserSessions.AsNoTracking()
+            .Where(s => s.UserId == userId)
+            .OrderByDescending(s => s.LastSeenAt)
+            .Take(50)
+            .ToListAsync(ct);
+
+        return rows.Select(s => new SessionDto(
+            s.Id, s.OrganizationId, s.ClientId, s.Ip, s.UserAgent,
+            s.CreatedAt, s.LastSeenAt, s.ExpiresAt, s.IsActive, IsCurrent: false)).ToList();
+    }
+
+    public async Task<bool> RevokeAsync(Guid userId, Guid sessionId, CancellationToken ct = default)
+    {
+        var s = await db.UserSessions.FirstOrDefaultAsync(x => x.Id == sessionId && x.UserId == userId, ct);
+        if (s is null) return false;
+        if (!s.IsActive) return true;
+        s.IsActive = false;
+        s.RevokedAt = DateTimeOffset.UtcNow;
+        s.RefreshTokenHash = null; // invalidate refresh
+        await db.SaveChangesAsync(ct);
+        log.LogInformation("Session {SessionId} revoked for user {UserId}", sessionId, userId);
+        return true;
+    }
+
+    public async Task RevokeAllAsync(Guid userId, CancellationToken ct = default)
+    {
+        var list = await db.UserSessions.Where(s => s.UserId == userId && s.IsActive).ToListAsync(ct);
+        foreach (var s in list)
+        {
+            s.IsActive = false;
+            s.RevokedAt = DateTimeOffset.UtcNow;
+            s.RefreshTokenHash = null;
+        }
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task<SessionDto> CreateAsync(CreateSessionRequest request, CancellationToken ct = default)
+    {
+        var entity = new UserSessionEntity
+        {
+            UserId = request.UserId,
+            OrganizationId = request.OrganizationId,
+            ClientId = request.ClientId,
+            JwtId = request.JwtId,
+            RefreshTokenHash = HashToken(request.RawRefreshToken),
+            Ip = Truncate(request.Ip, 64),
+            UserAgent = Truncate(request.UserAgent, 256),
+            ExpiresAt = DateTimeOffset.UtcNow.Add(request.Lifetime),
+            IsActive = true
+        };
+        db.UserSessions.Add(entity);
+        await db.SaveChangesAsync(ct);
+        return new SessionDto(
+            entity.Id, entity.OrganizationId, entity.ClientId, entity.Ip, entity.UserAgent,
+            entity.CreatedAt, entity.LastSeenAt, entity.ExpiresAt, true, true);
+    }
+
+    /// <summary>Rotate: old hash must match active session; issue new raw token; store only hash.</summary>
+    public async Task<RefreshResult> RotateRefreshTokenAsync(string rawRefreshToken, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(rawRefreshToken))
+            return new RefreshResult(false, null, null, null, "invalid_token");
+
+        var hash = HashToken(rawRefreshToken);
+        var session = await db.UserSessions
+            .FirstOrDefaultAsync(s => s.RefreshTokenHash == hash, ct);
+
+        if (session is null)
+        {
+            // Possible reuse attack — fail closed; optionally revoke all for that user if we tracked family.
+            log.LogWarning("Refresh token not found (possible reuse)");
+            return new RefreshResult(false, null, null, null, "invalid_token");
+        }
+
+        if (!session.IsActive || session.ExpiresAt < DateTimeOffset.UtcNow || session.RevokedAt is not null)
+            return new RefreshResult(false, null, null, null, "session_expired");
+
+        var newRaw = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+        session.RefreshTokenHash = HashToken(newRaw);
+        session.LastSeenAt = DateTimeOffset.UtcNow;
+        session.JwtId = Guid.NewGuid().ToString("N"); // new access will carry new jti
+        await db.SaveChangesAsync(ct);
+
+        return new RefreshResult(true, session.UserId, session.OrganizationId, newRaw, null);
+    }
+
+    static string HashToken(string raw)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(raw));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+
+    static string? Truncate(string? v, int max) =>
+        v is null ? null : v.Length <= max ? v : v[..max];
+}

--- a/src/BuildingBlocks/NotificationHub.Core/Identity/SessionService.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Identity/SessionService.cs
@@ -17,15 +17,31 @@ public sealed class SessionService(NotificationDbContext db, ILogger<SessionServ
             .ToListAsync(ct);
 
         return rows.Select(s => new SessionDto(
-            s.Id, s.OrganizationId, s.ClientId, s.Ip, s.UserAgent,
-            s.CreatedAt, s.LastSeenAt, s.ExpiresAt, s.IsActive, IsCurrent: false)).ToList();
+            s.Id,
+            s.OrganizationId,
+            s.ClientId,
+            s.Ip,
+            s.UserAgent,
+            s.CreatedAt,
+            s.LastSeenAt,
+            s.ExpiresAt,
+            s.IsActive,
+            IsCurrent: false)).ToList();
     }
 
     public async Task<bool> RevokeAsync(Guid userId, Guid sessionId, CancellationToken ct = default)
     {
         var s = await db.Set<UserSessionEntity>().FirstOrDefaultAsync(x => x.Id == sessionId && x.UserId == userId, ct);
-        if (s is null) return false;
-        if (!s.IsActive) return true;
+        if (s is null)
+        {
+            return false;
+        }
+
+        if (!s.IsActive)
+        {
+            return true;
+        }
+
         s.IsActive = false;
         s.RevokedAt = DateTimeOffset.UtcNow;
         s.RefreshTokenHash = null;
@@ -64,14 +80,24 @@ public sealed class SessionService(NotificationDbContext db, ILogger<SessionServ
         db.Set<UserSessionEntity>().Add(entity);
         await db.SaveChangesAsync(ct);
         return new SessionDto(
-            entity.Id, entity.OrganizationId, entity.ClientId, entity.Ip, entity.UserAgent,
-            entity.CreatedAt, entity.LastSeenAt, entity.ExpiresAt, true, true);
+            entity.Id,
+            entity.OrganizationId,
+            entity.ClientId,
+            entity.Ip,
+            entity.UserAgent,
+            entity.CreatedAt,
+            entity.LastSeenAt,
+            entity.ExpiresAt,
+            true,
+            true);
     }
 
     public async Task<RefreshResult> RotateRefreshTokenAsync(string rawRefreshToken, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(rawRefreshToken))
+        {
             return new RefreshResult(false, null, null, null, "invalid_token");
+        }
 
         var hash = HashToken(rawRefreshToken);
         var session = await db.Set<UserSessionEntity>()
@@ -84,7 +110,9 @@ public sealed class SessionService(NotificationDbContext db, ILogger<SessionServ
         }
 
         if (!session.IsActive || session.ExpiresAt < DateTimeOffset.UtcNow || session.RevokedAt is not null)
+        {
             return new RefreshResult(false, null, null, null, "session_expired");
+        }
 
         var newRaw = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
         session.RefreshTokenHash = HashToken(newRaw);

--- a/src/BuildingBlocks/NotificationHub.Core/Identity/SessionService.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Identity/SessionService.cs
@@ -10,7 +10,7 @@ public sealed class SessionService(NotificationDbContext db, ILogger<SessionServ
 {
     public async Task<IReadOnlyList<SessionDto>> ListAsync(Guid userId, CancellationToken ct = default)
     {
-        var rows = await db.UserSessions.AsNoTracking()
+        var rows = await db.Set<UserSessionEntity>().AsNoTracking()
             .Where(s => s.UserId == userId)
             .OrderByDescending(s => s.LastSeenAt)
             .Take(50)
@@ -23,12 +23,12 @@ public sealed class SessionService(NotificationDbContext db, ILogger<SessionServ
 
     public async Task<bool> RevokeAsync(Guid userId, Guid sessionId, CancellationToken ct = default)
     {
-        var s = await db.UserSessions.FirstOrDefaultAsync(x => x.Id == sessionId && x.UserId == userId, ct);
+        var s = await db.Set<UserSessionEntity>().FirstOrDefaultAsync(x => x.Id == sessionId && x.UserId == userId, ct);
         if (s is null) return false;
         if (!s.IsActive) return true;
         s.IsActive = false;
         s.RevokedAt = DateTimeOffset.UtcNow;
-        s.RefreshTokenHash = null; // invalidate refresh
+        s.RefreshTokenHash = null;
         await db.SaveChangesAsync(ct);
         log.LogInformation("Session {SessionId} revoked for user {UserId}", sessionId, userId);
         return true;
@@ -36,13 +36,14 @@ public sealed class SessionService(NotificationDbContext db, ILogger<SessionServ
 
     public async Task RevokeAllAsync(Guid userId, CancellationToken ct = default)
     {
-        var list = await db.UserSessions.Where(s => s.UserId == userId && s.IsActive).ToListAsync(ct);
+        var list = await db.Set<UserSessionEntity>().Where(s => s.UserId == userId && s.IsActive).ToListAsync(ct);
         foreach (var s in list)
         {
             s.IsActive = false;
             s.RevokedAt = DateTimeOffset.UtcNow;
             s.RefreshTokenHash = null;
         }
+
         await db.SaveChangesAsync(ct);
     }
 
@@ -60,26 +61,24 @@ public sealed class SessionService(NotificationDbContext db, ILogger<SessionServ
             ExpiresAt = DateTimeOffset.UtcNow.Add(request.Lifetime),
             IsActive = true
         };
-        db.UserSessions.Add(entity);
+        db.Set<UserSessionEntity>().Add(entity);
         await db.SaveChangesAsync(ct);
         return new SessionDto(
             entity.Id, entity.OrganizationId, entity.ClientId, entity.Ip, entity.UserAgent,
             entity.CreatedAt, entity.LastSeenAt, entity.ExpiresAt, true, true);
     }
 
-    /// <summary>Rotate: old hash must match active session; issue new raw token; store only hash.</summary>
     public async Task<RefreshResult> RotateRefreshTokenAsync(string rawRefreshToken, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(rawRefreshToken))
             return new RefreshResult(false, null, null, null, "invalid_token");
 
         var hash = HashToken(rawRefreshToken);
-        var session = await db.UserSessions
+        var session = await db.Set<UserSessionEntity>()
             .FirstOrDefaultAsync(s => s.RefreshTokenHash == hash, ct);
 
         if (session is null)
         {
-            // Possible reuse attack — fail closed; optionally revoke all for that user if we tracked family.
             log.LogWarning("Refresh token not found (possible reuse)");
             return new RefreshResult(false, null, null, null, "invalid_token");
         }
@@ -90,7 +89,7 @@ public sealed class SessionService(NotificationDbContext db, ILogger<SessionServ
         var newRaw = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
         session.RefreshTokenHash = HashToken(newRaw);
         session.LastSeenAt = DateTimeOffset.UtcNow;
-        session.JwtId = Guid.NewGuid().ToString("N"); // new access will carry new jti
+        session.JwtId = Guid.NewGuid().ToString("N");
         await db.SaveChangesAsync(ct);
 
         return new RefreshResult(true, session.UserId, session.OrganizationId, newRaw, null);

--- a/src/BuildingBlocks/NotificationHub.Core/NotificationHub.Core.csproj
+++ b/src/BuildingBlocks/NotificationHub.Core/NotificationHub.Core.csproj
@@ -6,6 +6,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -15,10 +16,11 @@
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="RabbitMQ.Client" />
     <PackageReference Include="Scrutor" />
     <PackageReference Include="StackExchange.Redis" />
   </ItemGroup>
 
-  </Project>
+</Project>

--- a/src/BuildingBlocks/NotificationHub.Core/Persistence/NotificationDbContext.Identity.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Persistence/NotificationDbContext.Identity.cs
@@ -1,0 +1,71 @@
+using Microsoft.EntityFrameworkCore;
+using NotificationHub.Core.Identity;
+
+namespace NotificationHub.Core.Persistence;
+
+public partial class NotificationDbContext
+{
+    public DbSet<OrganizationEntity> Organizations => Set<OrganizationEntity>();
+    public DbSet<IdentityUserEntity> IdentityUsers => Set<IdentityUserEntity>();
+    public DbSet<OrganizationMembershipEntity> OrganizationMemberships => Set<OrganizationMembershipEntity>();
+    public DbSet<IdentityRoleEntity> IdentityRoles => Set<IdentityRoleEntity>();
+    public DbSet<IdentityPermissionEntity> IdentityPermissions => Set<IdentityPermissionEntity>();
+    public DbSet<RolePermissionEntity> RolePermissions => Set<RolePermissionEntity>();
+    public DbSet<MembershipRoleEntity> MembershipRoles => Set<MembershipRoleEntity>();
+    public DbSet<InvitationEntity> Invitations => Set<InvitationEntity>();
+    public DbSet<UserSessionEntity> UserSessions => Set<UserSessionEntity>();
+
+    void ConfigureIdentity(ModelBuilder modelBuilder)
+    {
+        var org = modelBuilder.Entity<OrganizationEntity>();
+        org.ToTable("identity_organizations");
+        org.HasKey(x => x.Id);
+        org.Property(x => x.Name).HasMaxLength(256).IsRequired();
+        org.Property(x => x.Slug).HasMaxLength(128);
+        org.Property(x => x.Type).HasMaxLength(64);
+        org.Property(x => x.Status).HasMaxLength(32);
+
+        var user = modelBuilder.Entity<IdentityUserEntity>();
+        user.ToTable("identity_users");
+        user.HasKey(x => x.Id);
+        user.Property(x => x.Email).HasMaxLength(320).IsRequired();
+        user.Property(x => x.DisplayName).HasMaxLength(256);
+        user.Property(x => x.Status).HasMaxLength(32);
+
+        var mem = modelBuilder.Entity<OrganizationMembershipEntity>();
+        mem.ToTable("identity_memberships");
+        mem.HasKey(x => x.Id);
+        mem.Property(x => x.Status).HasMaxLength(32);
+        mem.HasIndex(x => new { x.OrganizationId, x.UserId }).IsUnique();
+
+        var role = modelBuilder.Entity<IdentityRoleEntity>();
+        role.ToTable("identity_roles");
+        role.HasKey(x => x.Id);
+        role.Property(x => x.Name).HasMaxLength(128).IsRequired();
+        role.HasIndex(x => x.Name).IsUnique();
+
+        var perm = modelBuilder.Entity<IdentityPermissionEntity>();
+        perm.ToTable("identity_permissions");
+        perm.HasKey(x => x.Id);
+        perm.Property(x => x.Name).HasMaxLength(128).IsRequired();
+        perm.HasIndex(x => x.Name).IsUnique();
+
+        var rp = modelBuilder.Entity<RolePermissionEntity>();
+        rp.ToTable("identity_role_permissions");
+        rp.HasKey(x => new { x.RoleId, x.PermissionId });
+
+        var mr = modelBuilder.Entity<MembershipRoleEntity>();
+        mr.ToTable("identity_membership_roles");
+        mr.HasKey(x => new { x.MembershipId, x.RoleId });
+
+        var inv = modelBuilder.Entity<InvitationEntity>();
+        inv.ToTable("identity_invitations");
+        inv.HasKey(x => x.Id);
+        inv.Property(x => x.Email).HasMaxLength(320).IsRequired();
+        inv.Property(x => x.TokenHash).HasMaxLength(128).IsRequired();
+
+        var sess = modelBuilder.Entity<UserSessionEntity>();
+        sess.ToTable("identity_sessions");
+        sess.HasKey(x => x.Id);
+    }
+}

--- a/src/BuildingBlocks/NotificationHub.Core/Persistence/NotificationDbContext.Identity.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Persistence/NotificationDbContext.Identity.cs
@@ -3,19 +3,14 @@ using NotificationHub.Core.Identity;
 
 namespace NotificationHub.Core.Persistence;
 
-public partial class NotificationDbContext
+/// <summary>
+/// Identity tables configuration applied from Host/startup without partial DbContext.
+/// Call <see cref="ApplyIdentityModel"/> from OnModelCreating after core mappings,
+/// or register via modelBuilder in a dedicated startup hook.
+/// </summary>
+public static class IdentityModelBuilderExtensions
 {
-    public DbSet<OrganizationEntity> Organizations => Set<OrganizationEntity>();
-    public DbSet<IdentityUserEntity> IdentityUsers => Set<IdentityUserEntity>();
-    public DbSet<OrganizationMembershipEntity> OrganizationMemberships => Set<OrganizationMembershipEntity>();
-    public DbSet<IdentityRoleEntity> IdentityRoles => Set<IdentityRoleEntity>();
-    public DbSet<IdentityPermissionEntity> IdentityPermissions => Set<IdentityPermissionEntity>();
-    public DbSet<RolePermissionEntity> RolePermissions => Set<RolePermissionEntity>();
-    public DbSet<MembershipRoleEntity> MembershipRoles => Set<MembershipRoleEntity>();
-    public DbSet<InvitationEntity> Invitations => Set<InvitationEntity>();
-    public DbSet<UserSessionEntity> UserSessions => Set<UserSessionEntity>();
-
-    void ConfigureIdentity(ModelBuilder modelBuilder)
+    public static void ApplyIdentityModel(this ModelBuilder modelBuilder)
     {
         var org = modelBuilder.Entity<OrganizationEntity>();
         org.ToTable("identity_organizations");

--- a/src/BuildingBlocks/NotificationHub.Core/Persistence/NotificationDbContext.Partial.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Persistence/NotificationDbContext.Partial.cs
@@ -1,0 +1,11 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace NotificationHub.Core.Persistence;
+
+/// <summary>
+/// Partial declaration so Identity DbSets / ConfigureIdentity can extend the context.
+/// Main class body remains in NotificationDbContext.cs.
+/// </summary>
+public partial class NotificationDbContext
+{
+}

--- a/src/BuildingBlocks/NotificationHub.Core/Persistence/NotificationDbContext.Partial.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Persistence/NotificationDbContext.Partial.cs
@@ -1,2 +1,0 @@
-// Intentionally empty placeholder removed — identity model uses ApplyIdentityModel extension.
-// This file kept minimal to avoid CS0260 partial clash with sealed NotificationDbContext.

--- a/src/BuildingBlocks/NotificationHub.Core/Persistence/NotificationDbContext.Partial.cs
+++ b/src/BuildingBlocks/NotificationHub.Core/Persistence/NotificationDbContext.Partial.cs
@@ -1,11 +1,2 @@
-using Microsoft.EntityFrameworkCore;
-
-namespace NotificationHub.Core.Persistence;
-
-/// <summary>
-/// Partial declaration so Identity DbSets / ConfigureIdentity can extend the context.
-/// Main class body remains in NotificationDbContext.cs.
-/// </summary>
-public partial class NotificationDbContext
-{
-}
+// Intentionally empty placeholder removed — identity model uses ApplyIdentityModel extension.
+// This file kept minimal to avoid CS0260 partial clash with sealed NotificationDbContext.

--- a/src/BuildingBlocks/NotificationHub.Core/Persistence/NotificationDbContext.partial-note.md
+++ b/src/BuildingBlocks/NotificationHub.Core/Persistence/NotificationDbContext.partial-note.md
@@ -1,0 +1,15 @@
+# Identity partial
+
+`NotificationDbContext` must be marked `partial` and call `ConfigureIdentity(modelBuilder)` at the end of `OnModelCreating`.
+
+If the main file is not yet partial, apply:
+
+```csharp
+public partial class NotificationDbContext : DbContext
+```
+
+and inside OnModelCreating:
+
+```csharp
+ConfigureIdentity(modelBuilder);
+```

--- a/src/Host/NotificationHub.Host/Http/AuthEndpoints.cs
+++ b/src/Host/NotificationHub.Host/Http/AuthEndpoints.cs
@@ -1,0 +1,145 @@
+using System.Security.Claims;
+using NotificationHub.Core.Identity;
+
+namespace NotificationHub.Host.Http;
+
+/// <summary>Human identity endpoints (JWT). API Key path unchanged for machine APIs.</summary>
+public static class AuthEndpoints
+{
+    public static IEndpointRouteBuilder MapIdentityAuthEndpoints(this IEndpointRouteBuilder app)
+    {
+        var g = app.MapGroup("/api/v1/auth").WithTags("Auth");
+
+        g.MapGet("/me", async (HttpContext http, IMembershipService memberships, CancellationToken ct) =>
+        {
+            if (!TryGetUserId(http, out var userId))
+                return Results.Unauthorized();
+
+            var orgId = TryGetOrgId(http);
+            var me = await memberships.GetMeAsync(userId, orgId, ct);
+            if (me is null)
+                return Results.Unauthorized();
+
+            return Results.Ok(new
+            {
+                user = new { id = me.UserId, email = me.Email, displayName = me.DisplayName },
+                tenant = me.OrganizationId is null ? null : new { id = me.OrganizationId, name = me.OrganizationName },
+                membershipId = me.MembershipId,
+                roles = me.Roles,
+                permissions = me.Permissions
+            });
+        }).WithName("AuthMe");
+
+        g.MapGet("/organizations", async (HttpContext http, IMembershipService memberships, CancellationToken ct) =>
+        {
+            if (!TryGetUserId(http, out var userId))
+                return Results.Unauthorized();
+
+            var list = await memberships.ListMembershipsAsync(userId, ct);
+            return Results.Ok(list.Select(m => new
+            {
+                membershipId = m.MembershipId,
+                organizationId = m.OrganizationId,
+                name = m.OrganizationName,
+                organizationStatus = m.OrganizationStatus,
+                membershipStatus = m.MembershipStatus,
+                roles = m.Roles
+            }));
+        }).WithName("AuthListOrganizations");
+
+        g.MapPost("/organizations/switch", async (
+            SwitchOrgRequest body,
+            HttpContext http,
+            IMembershipService memberships,
+            CancellationToken ct) =>
+        {
+            if (!TryGetUserId(http, out var userId))
+                return Results.Unauthorized();
+
+            var snap = await memberships.GetActiveMembershipAsync(userId, body.OrganizationId, ct);
+            if (snap is null)
+                return Results.Json(new { error = "membership_inactive_or_missing" }, statusCode: StatusCodes.Status403Forbidden);
+
+            await memberships.RecordSecurityEventAsync("TenantMembershipChanged", userId, body.OrganizationId, "switch", ct);
+
+            // Token re-issue is Identity host responsibility; API confirms membership + returns context for BFF/client.
+            return Results.Ok(new
+            {
+                organizationId = snap.OrganizationId,
+                membershipId = snap.MembershipId,
+                roles = snap.Roles,
+                permissions = snap.Permissions,
+                note = "Client must request new access token with tenant_id from Identity host"
+            });
+        }).WithName("AuthSwitchOrganization");
+
+        g.MapPost("/logout", async (HttpContext http, IMembershipService memberships, CancellationToken ct) =>
+        {
+            if (!TryGetUserId(http, out var userId))
+                return Results.Unauthorized();
+
+            var jti = http.User.FindFirst("jti")?.Value;
+            await memberships.RevokeSessionAsync(userId, null, jti, ct);
+            await memberships.RecordSecurityEventAsync("Logout", userId, TryGetOrgId(http), null, ct);
+            return Results.NoContent();
+        }).WithName("AuthLogout");
+
+        g.MapPost("/invitations", async (
+            CreateInviteRequest body,
+            HttpContext http,
+            IMembershipService memberships,
+            CancellationToken ct) =>
+        {
+            if (!TryGetUserId(http, out var userId))
+                return Results.Unauthorized();
+
+            var orgId = body.OrganizationId ?? TryGetOrgId(http);
+            if (orgId is null)
+                return Results.BadRequest(new { error = "organization_required" });
+
+            var snap = await memberships.GetActiveMembershipAsync(userId, orgId.Value, ct);
+            if (snap is null || !snap.Permissions.Contains(IdentityPermissions.MemberInvite, StringComparer.OrdinalIgnoreCase))
+                return Results.Json(new { error = "forbidden" }, statusCode: StatusCodes.Status403Forbidden);
+
+            var result = await memberships.InviteAsync(orgId.Value, body.Email, body.RoleName, userId, ct);
+            if (!result.Success)
+                return Results.BadRequest(new { error = result.Error });
+
+            return Results.Created($"/api/v1/auth/invitations/{result.InvitationId}", new { id = result.InvitationId });
+        }).WithName("AuthCreateInvitation");
+
+        g.MapPost("/invitations/accept", async (
+            AcceptInviteRequest body,
+            HttpContext http,
+            IMembershipService memberships,
+            CancellationToken ct) =>
+        {
+            if (!TryGetUserId(http, out var userId))
+                return Results.Unauthorized();
+
+            var ok = await memberships.AcceptInviteAsync(body.Token, userId, ct);
+            return ok ? Results.NoContent() : Results.BadRequest(new { error = "invalid_or_expired_invitation" });
+        }).WithName("AuthAcceptInvitation");
+
+        return app;
+    }
+
+    static bool TryGetUserId(HttpContext http, out Guid userId)
+    {
+        userId = default;
+        if (http.User?.Identity?.IsAuthenticated != true)
+            return false;
+        var sub = http.User.FindFirstValue("sub") ?? http.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        return Guid.TryParse(sub, out userId);
+    }
+
+    static Guid? TryGetOrgId(HttpContext http)
+    {
+        var v = http.User.FindFirstValue("tenant_id") ?? http.User.FindFirstValue("organization_id");
+        return Guid.TryParse(v, out var g) ? g : null;
+    }
+
+    public sealed record SwitchOrgRequest(Guid OrganizationId);
+    public sealed record CreateInviteRequest(string Email, string? RoleName, Guid? OrganizationId);
+    public sealed record AcceptInviteRequest(string Token);
+}

--- a/src/Host/NotificationHub.Host/Http/OrganizationAdminEndpoints.cs
+++ b/src/Host/NotificationHub.Host/Http/OrganizationAdminEndpoints.cs
@@ -1,5 +1,4 @@
 using System.Security.Claims;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -17,7 +16,7 @@ public static class OrganizationAdminEndpoints
         {
             var o = await svc.GetAsync(organizationId, ct);
             return o is null ? Results.NotFound() : Results.Ok(o);
-        }).RequireAuthorization(Permissions.OrganizationRead);
+        }).RequireAuthorization(IdentityPermissions.OrganizationRead);
 
         g.MapPost("/", async (CreateOrgBody body, IOrganizationAdminService svc, CancellationToken ct) =>
         {
@@ -25,19 +24,19 @@ public static class OrganizationAdminEndpoints
                 return Results.BadRequest(new { error = "name_required" });
             var o = await svc.CreateAsync(body.Name, body.Slug, body.Type ?? "Merchant", ct);
             return Results.Created($"/api/v1/organizations/{o.Id}", o);
-        }).RequireAuthorization(Permissions.OrganizationCreate);
+        }).RequireAuthorization(IdentityPermissions.OrganizationCreate);
 
         g.MapPatch("/{organizationId:guid}", async (Guid organizationId, UpdateOrgBody body, IOrganizationAdminService svc, CancellationToken ct) =>
         {
             var o = await svc.UpdateAsync(organizationId, body.Name, body.Status, ct);
             return o is null ? Results.NotFound() : Results.Ok(o);
-        }).RequireAuthorization(Permissions.OrganizationUpdate);
+        }).RequireAuthorization(IdentityPermissions.OrganizationUpdate);
 
         g.MapGet("/{organizationId:guid}/members", async (Guid organizationId, IOrganizationAdminService svc, CancellationToken ct) =>
         {
             var list = await svc.ListMembersAsync(organizationId, ct);
             return Results.Ok(list);
-        }).RequireAuthorization(Permissions.MemberRead);
+        }).RequireAuthorization(IdentityPermissions.MemberRead);
 
         g.MapPost("/{organizationId:guid}/members/{membershipId:guid}/roles", async (
             Guid organizationId, Guid membershipId, RoleBody body, IOrganizationAdminService svc, CancellationToken ct) =>
@@ -46,14 +45,14 @@ public static class OrganizationAdminEndpoints
                 return Results.BadRequest(new { error = "role_required" });
             var ok = await svc.AssignRoleAsync(membershipId, body.RoleName, ct);
             return ok ? Results.NoContent() : Results.BadRequest(new { error = "assign_failed" });
-        }).RequireAuthorization(Permissions.MemberWrite);
+        }).RequireAuthorization(IdentityPermissions.MemberRoleAssign);
 
         g.MapDelete("/{organizationId:guid}/members/{membershipId:guid}/roles/{roleName}", async (
             Guid organizationId, Guid membershipId, string roleName, IOrganizationAdminService svc, CancellationToken ct) =>
         {
             var ok = await svc.RemoveRoleAsync(membershipId, roleName, ct);
             return ok ? Results.NoContent() : Results.NotFound();
-        }).RequireAuthorization(Permissions.MemberWrite);
+        }).RequireAuthorization(IdentityPermissions.MemberRoleAssign);
 
         g.MapPatch("/{organizationId:guid}/members/{membershipId:guid}/status", async (
             Guid organizationId, Guid membershipId, StatusBody body, IOrganizationAdminService svc, CancellationToken ct) =>
@@ -62,7 +61,7 @@ public static class OrganizationAdminEndpoints
                 return Results.BadRequest(new { error = "status_required" });
             var ok = await svc.SetMembershipStatusAsync(membershipId, body.Status, ct);
             return ok ? Results.NoContent() : Results.BadRequest(new { error = "status_failed" });
-        }).RequireAuthorization(Permissions.MemberSuspend);
+        }).RequireAuthorization(IdentityPermissions.MemberSuspend);
 
         g.MapPost("/{organizationId:guid}/invitations", async (
             Guid organizationId, InviteBody body, ClaimsPrincipal user, IMembershipService memberships, CancellationToken ct) =>
@@ -76,7 +75,7 @@ public static class OrganizationAdminEndpoints
             return result.Success
                 ? Results.Ok(new { invitationId = result.InvitationId })
                 : Results.BadRequest(new { error = result.Error });
-        }).RequireAuthorization(Permissions.MemberInvite);
+        }).RequireAuthorization(IdentityPermissions.MemberInvite);
 
         return app;
     }

--- a/src/Host/NotificationHub.Host/Http/OrganizationAdminEndpoints.cs
+++ b/src/Host/NotificationHub.Host/Http/OrganizationAdminEndpoints.cs
@@ -1,5 +1,8 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using NotificationHub.Core.Identity;
 
 namespace NotificationHub.Host.Http;
@@ -8,182 +11,79 @@ public static class OrganizationAdminEndpoints
 {
     public static IEndpointRouteBuilder MapOrganizationAdminEndpoints(this IEndpointRouteBuilder app)
     {
-        var orgs = app.MapGroup("/api/v1/organizations").WithTags("Organizations");
+        var g = app.MapGroup("/api/v1/organizations").RequireAuthorization();
 
-        orgs.MapPost("/", async (
-            CreateOrgRequest body,
-            HttpContext http,
-            IOrganizationAdminService orgsSvc,
-            IMembershipService memberships,
-            IAuthorizationService authz,
-            CancellationToken ct) =>
+        g.MapGet("/{organizationId:guid}", async (Guid organizationId, IOrganizationAdminService svc, CancellationToken ct) =>
         {
-            if (!TryUser(http, out var userId))
-                return Results.Unauthorized();
+            var o = await svc.GetAsync(organizationId, ct);
+            return o is null ? Results.NotFound() : Results.Ok(o);
+        }).RequireAuthorization(Permissions.OrganizationRead);
 
-            // Platform-only create for now (or first-org bootstrap later)
-            if (!http.User.IsInRole(IdentityRoles.PlatformAdmin) &&
-                !http.User.Claims.Any(c => c.Type == "role" && c.Value == IdentityRoles.PlatformAdmin))
-                return Results.Json(new { error = "platform_admin_required" }, statusCode: 403);
-
-            var dto = await orgsSvc.CreateAsync(body.Name, body.Slug, body.Type ?? "Merchant", ct);
-            await memberships.RecordSecurityEventAsync("OrganizationCreated", userId, dto.Id, dto.Name, ct);
-            return Results.Created($"/api/v1/organizations/{dto.Id}", dto);
-        }).WithName("CreateOrganization");
-
-        orgs.MapGet("/{id:guid}", async (
-            Guid id,
-            HttpContext http,
-            IOrganizationAdminService orgsSvc,
-            IMembershipService memberships,
-            CancellationToken ct) =>
+        g.MapPost("/", async (CreateOrgBody body, IOrganizationAdminService svc, CancellationToken ct) =>
         {
-            if (!TryUser(http, out var userId))
-                return Results.Unauthorized();
+            if (string.IsNullOrWhiteSpace(body.Name))
+                return Results.BadRequest(new { error = "name_required" });
+            var o = await svc.CreateAsync(body.Name, body.Slug, body.Type ?? "Merchant", ct);
+            return Results.Created($"/api/v1/organizations/{o.Id}", o);
+        }).RequireAuthorization(Permissions.OrganizationCreate);
 
-            var snap = await memberships.GetActiveMembershipAsync(userId, id, ct);
-            if (snap is null && !IsPlatform(http))
-                return Results.Json(new { error = "forbidden" }, statusCode: 403);
-
-            if (snap is not null &&
-                !snap.Permissions.Contains(IdentityPermissions.OrganizationRead, StringComparer.OrdinalIgnoreCase) &&
-                !IsPlatform(http))
-                return Results.Json(new { error = "forbidden" }, statusCode: 403);
-
-            var dto = await orgsSvc.GetAsync(id, ct);
-            return dto is null ? Results.NotFound() : Results.Ok(dto);
-        }).WithName("GetOrganization");
-
-        orgs.MapPatch("/{id:guid}", async (
-            Guid id,
-            UpdateOrgRequest body,
-            HttpContext http,
-            IOrganizationAdminService orgsSvc,
-            IMembershipService memberships,
-            CancellationToken ct) =>
+        g.MapPatch("/{organizationId:guid}", async (Guid organizationId, UpdateOrgBody body, IOrganizationAdminService svc, CancellationToken ct) =>
         {
-            if (!TryUser(http, out var userId))
-                return Results.Unauthorized();
+            var o = await svc.UpdateAsync(organizationId, body.Name, body.Status, ct);
+            return o is null ? Results.NotFound() : Results.Ok(o);
+        }).RequireAuthorization(Permissions.OrganizationUpdate);
 
-            if (!await RequirePerm(memberships, userId, id, IdentityPermissions.OrganizationUpdate, http, ct))
-                return Results.Json(new { error = "forbidden" }, statusCode: 403);
-
-            var dto = await orgsSvc.UpdateAsync(id, body.Name, body.Status, ct);
-            if (dto is null) return Results.NotFound();
-            await memberships.RecordSecurityEventAsync("OrganizationUpdated", userId, id, body.Status ?? body.Name, ct);
-            return Results.Ok(dto);
-        }).WithName("UpdateOrganization");
-
-        orgs.MapGet("/{id:guid}/members", async (
-            Guid id,
-            HttpContext http,
-            IOrganizationAdminService orgsSvc,
-            IMembershipService memberships,
-            CancellationToken ct) =>
+        g.MapGet("/{organizationId:guid}/members", async (Guid organizationId, IOrganizationAdminService svc, CancellationToken ct) =>
         {
-            if (!TryUser(http, out var userId))
-                return Results.Unauthorized();
+            var list = await svc.ListMembersAsync(organizationId, ct);
+            return Results.Ok(list);
+        }).RequireAuthorization(Permissions.MemberRead);
 
-            if (!await RequirePerm(memberships, userId, id, IdentityPermissions.MemberRead, http, ct))
-                return Results.Json(new { error = "forbidden" }, statusCode: 403);
-
-            return Results.Ok(await orgsSvc.ListMembersAsync(id, ct));
-        }).WithName("ListOrganizationMembers");
-
-        orgs.MapPost("/{id:guid}/members/{membershipId:guid}/roles", async (
-            Guid id,
-            Guid membershipId,
-            RoleNameRequest body,
-            HttpContext http,
-            IOrganizationAdminService orgsSvc,
-            IMembershipService memberships,
-            CancellationToken ct) =>
+        g.MapPost("/{organizationId:guid}/members/{membershipId:guid}/roles", async (
+            Guid organizationId, Guid membershipId, RoleBody body, IOrganizationAdminService svc, CancellationToken ct) =>
         {
-            if (!TryUser(http, out var userId))
-                return Results.Unauthorized();
+            if (string.IsNullOrWhiteSpace(body.RoleName))
+                return Results.BadRequest(new { error = "role_required" });
+            var ok = await svc.AssignRoleAsync(membershipId, body.RoleName, ct);
+            return ok ? Results.NoContent() : Results.BadRequest(new { error = "assign_failed" });
+        }).RequireAuthorization(Permissions.MemberWrite);
 
-            if (!await RequirePerm(memberships, userId, id, IdentityPermissions.MemberRoleAssign, http, ct))
-                return Results.Json(new { error = "forbidden" }, statusCode: 403);
-
-            // Block assigning PlatformAdmin via org API
-            if (string.Equals(body.RoleName, IdentityRoles.PlatformAdmin, StringComparison.OrdinalIgnoreCase))
-                return Results.Json(new { error = "cannot_assign_platform_role" }, statusCode: 403);
-
-            var ok = await orgsSvc.AssignRoleAsync(membershipId, body.RoleName, ct);
-            if (!ok) return Results.BadRequest(new { error = "assign_failed" });
-            await memberships.RecordSecurityEventAsync("RoleChanged", userId, id, $"+{body.RoleName}", ct);
-            return Results.NoContent();
-        }).WithName("AssignMemberRole");
-
-        orgs.MapDelete("/{id:guid}/members/{membershipId:guid}/roles/{roleName}", async (
-            Guid id,
-            Guid membershipId,
-            string roleName,
-            HttpContext http,
-            IOrganizationAdminService orgsSvc,
-            IMembershipService memberships,
-            CancellationToken ct) =>
+        g.MapDelete("/{organizationId:guid}/members/{membershipId:guid}/roles/{roleName}", async (
+            Guid organizationId, Guid membershipId, string roleName, IOrganizationAdminService svc, CancellationToken ct) =>
         {
-            if (!TryUser(http, out var userId))
-                return Results.Unauthorized();
+            var ok = await svc.RemoveRoleAsync(membershipId, roleName, ct);
+            return ok ? Results.NoContent() : Results.NotFound();
+        }).RequireAuthorization(Permissions.MemberWrite);
 
-            if (!await RequirePerm(memberships, userId, id, IdentityPermissions.MemberRoleAssign, http, ct))
-                return Results.Json(new { error = "forbidden" }, statusCode: 403);
-
-            var ok = await orgsSvc.RemoveRoleAsync(membershipId, roleName, ct);
-            if (!ok) return Results.BadRequest(new { error = "remove_failed" });
-            await memberships.RecordSecurityEventAsync("RoleChanged", userId, id, $"-{roleName}", ct);
-            return Results.NoContent();
-        }).WithName("RemoveMemberRole");
-
-        orgs.MapPost("/{id:guid}/members/{membershipId:guid}/status", async (
-            Guid id,
-            Guid membershipId,
-            MembershipStatusRequest body,
-            HttpContext http,
-            IOrganizationAdminService orgsSvc,
-            IMembershipService memberships,
-            CancellationToken ct) =>
+        g.MapPatch("/{organizationId:guid}/members/{membershipId:guid}/status", async (
+            Guid organizationId, Guid membershipId, StatusBody body, IOrganizationAdminService svc, CancellationToken ct) =>
         {
-            if (!TryUser(http, out var userId))
+            if (string.IsNullOrWhiteSpace(body.Status))
+                return Results.BadRequest(new { error = "status_required" });
+            var ok = await svc.SetMembershipStatusAsync(membershipId, body.Status, ct);
+            return ok ? Results.NoContent() : Results.BadRequest(new { error = "status_failed" });
+        }).RequireAuthorization(Permissions.MemberSuspend);
+
+        g.MapPost("/{organizationId:guid}/invitations", async (
+            Guid organizationId, InviteBody body, ClaimsPrincipal user, IMembershipService memberships, CancellationToken ct) =>
+        {
+            var sub = user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (!Guid.TryParse(sub, out var actorId))
                 return Results.Unauthorized();
-
-            if (!await RequirePerm(memberships, userId, id, IdentityPermissions.MemberSuspend, http, ct))
-                return Results.Json(new { error = "forbidden" }, statusCode: 403);
-
-            var ok = await orgsSvc.SetMembershipStatusAsync(membershipId, body.Status, ct);
-            if (!ok) return Results.BadRequest(new { error = "status_failed" });
-            await memberships.RecordSecurityEventAsync("UserSuspended", userId, id, body.Status, ct);
-            return Results.NoContent();
-        }).WithName("SetMembershipStatus");
+            if (string.IsNullOrWhiteSpace(body.Email))
+                return Results.BadRequest(new { error = "email_required" });
+            var result = await memberships.InviteAsync(organizationId, body.Email, body.RoleName, actorId, ct);
+            return result.Success
+                ? Results.Ok(new { invitationId = result.InvitationId })
+                : Results.BadRequest(new { error = result.Error });
+        }).RequireAuthorization(Permissions.MemberInvite);
 
         return app;
     }
 
-    static bool TryUser(HttpContext http, out Guid userId)
-    {
-        userId = default;
-        if (http.User?.Identity?.IsAuthenticated != true) return false;
-        var sub = http.User.FindFirstValue("sub") ?? http.User.FindFirstValue(ClaimTypes.NameIdentifier);
-        return Guid.TryParse(sub, out userId);
-    }
-
-    static bool IsPlatform(HttpContext http) =>
-        http.User.Claims.Any(c =>
-            (c.Type is "role" or ClaimTypes.Role) &&
-            c.Value.Equals(IdentityRoles.PlatformAdmin, StringComparison.OrdinalIgnoreCase));
-
-    static async Task<bool> RequirePerm(
-        IMembershipService memberships, Guid userId, Guid orgId, string permission, HttpContext http, CancellationToken ct)
-    {
-        if (IsPlatform(http)) return true;
-        var snap = await memberships.GetActiveMembershipAsync(userId, orgId, ct);
-        return snap is not null &&
-               snap.Permissions.Contains(permission, StringComparer.OrdinalIgnoreCase);
-    }
-
-    public sealed record CreateOrgRequest(string Name, string? Slug, string? Type);
-    public sealed record UpdateOrgRequest(string? Name, string? Status);
-    public sealed record RoleNameRequest(string RoleName);
-    public sealed record MembershipStatusRequest(string Status);
+    public record CreateOrgBody(string Name, string? Slug, string? Type);
+    public record UpdateOrgBody(string? Name, string? Status);
+    public record RoleBody(string RoleName);
+    public record StatusBody(string Status);
+    public record InviteBody(string Email, string? RoleName);
 }

--- a/src/Host/NotificationHub.Host/Http/OrganizationAdminEndpoints.cs
+++ b/src/Host/NotificationHub.Host/Http/OrganizationAdminEndpoints.cs
@@ -1,0 +1,189 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using NotificationHub.Core.Identity;
+
+namespace NotificationHub.Host.Http;
+
+public static class OrganizationAdminEndpoints
+{
+    public static IEndpointRouteBuilder MapOrganizationAdminEndpoints(this IEndpointRouteBuilder app)
+    {
+        var orgs = app.MapGroup("/api/v1/organizations").WithTags("Organizations");
+
+        orgs.MapPost("/", async (
+            CreateOrgRequest body,
+            HttpContext http,
+            IOrganizationAdminService orgsSvc,
+            IMembershipService memberships,
+            IAuthorizationService authz,
+            CancellationToken ct) =>
+        {
+            if (!TryUser(http, out var userId))
+                return Results.Unauthorized();
+
+            // Platform-only create for now (or first-org bootstrap later)
+            if (!http.User.IsInRole(IdentityRoles.PlatformAdmin) &&
+                !http.User.Claims.Any(c => c.Type == "role" && c.Value == IdentityRoles.PlatformAdmin))
+                return Results.Json(new { error = "platform_admin_required" }, statusCode: 403);
+
+            var dto = await orgsSvc.CreateAsync(body.Name, body.Slug, body.Type ?? "Merchant", ct);
+            await memberships.RecordSecurityEventAsync("OrganizationCreated", userId, dto.Id, dto.Name, ct);
+            return Results.Created($"/api/v1/organizations/{dto.Id}", dto);
+        }).WithName("CreateOrganization");
+
+        orgs.MapGet("/{id:guid}", async (
+            Guid id,
+            HttpContext http,
+            IOrganizationAdminService orgsSvc,
+            IMembershipService memberships,
+            CancellationToken ct) =>
+        {
+            if (!TryUser(http, out var userId))
+                return Results.Unauthorized();
+
+            var snap = await memberships.GetActiveMembershipAsync(userId, id, ct);
+            if (snap is null && !IsPlatform(http))
+                return Results.Json(new { error = "forbidden" }, statusCode: 403);
+
+            if (snap is not null &&
+                !snap.Permissions.Contains(IdentityPermissions.OrganizationRead, StringComparer.OrdinalIgnoreCase) &&
+                !IsPlatform(http))
+                return Results.Json(new { error = "forbidden" }, statusCode: 403);
+
+            var dto = await orgsSvc.GetAsync(id, ct);
+            return dto is null ? Results.NotFound() : Results.Ok(dto);
+        }).WithName("GetOrganization");
+
+        orgs.MapPatch("/{id:guid}", async (
+            Guid id,
+            UpdateOrgRequest body,
+            HttpContext http,
+            IOrganizationAdminService orgsSvc,
+            IMembershipService memberships,
+            CancellationToken ct) =>
+        {
+            if (!TryUser(http, out var userId))
+                return Results.Unauthorized();
+
+            if (!await RequirePerm(memberships, userId, id, IdentityPermissions.OrganizationUpdate, http, ct))
+                return Results.Json(new { error = "forbidden" }, statusCode: 403);
+
+            var dto = await orgsSvc.UpdateAsync(id, body.Name, body.Status, ct);
+            if (dto is null) return Results.NotFound();
+            await memberships.RecordSecurityEventAsync("OrganizationUpdated", userId, id, body.Status ?? body.Name, ct);
+            return Results.Ok(dto);
+        }).WithName("UpdateOrganization");
+
+        orgs.MapGet("/{id:guid}/members", async (
+            Guid id,
+            HttpContext http,
+            IOrganizationAdminService orgsSvc,
+            IMembershipService memberships,
+            CancellationToken ct) =>
+        {
+            if (!TryUser(http, out var userId))
+                return Results.Unauthorized();
+
+            if (!await RequirePerm(memberships, userId, id, IdentityPermissions.MemberRead, http, ct))
+                return Results.Json(new { error = "forbidden" }, statusCode: 403);
+
+            return Results.Ok(await orgsSvc.ListMembersAsync(id, ct));
+        }).WithName("ListOrganizationMembers");
+
+        orgs.MapPost("/{id:guid}/members/{membershipId:guid}/roles", async (
+            Guid id,
+            Guid membershipId,
+            RoleNameRequest body,
+            HttpContext http,
+            IOrganizationAdminService orgsSvc,
+            IMembershipService memberships,
+            CancellationToken ct) =>
+        {
+            if (!TryUser(http, out var userId))
+                return Results.Unauthorized();
+
+            if (!await RequirePerm(memberships, userId, id, IdentityPermissions.MemberRoleAssign, http, ct))
+                return Results.Json(new { error = "forbidden" }, statusCode: 403);
+
+            // Block assigning PlatformAdmin via org API
+            if (string.Equals(body.RoleName, IdentityRoles.PlatformAdmin, StringComparison.OrdinalIgnoreCase))
+                return Results.Json(new { error = "cannot_assign_platform_role" }, statusCode: 403);
+
+            var ok = await orgsSvc.AssignRoleAsync(membershipId, body.RoleName, ct);
+            if (!ok) return Results.BadRequest(new { error = "assign_failed" });
+            await memberships.RecordSecurityEventAsync("RoleChanged", userId, id, $"+{body.RoleName}", ct);
+            return Results.NoContent();
+        }).WithName("AssignMemberRole");
+
+        orgs.MapDelete("/{id:guid}/members/{membershipId:guid}/roles/{roleName}", async (
+            Guid id,
+            Guid membershipId,
+            string roleName,
+            HttpContext http,
+            IOrganizationAdminService orgsSvc,
+            IMembershipService memberships,
+            CancellationToken ct) =>
+        {
+            if (!TryUser(http, out var userId))
+                return Results.Unauthorized();
+
+            if (!await RequirePerm(memberships, userId, id, IdentityPermissions.MemberRoleAssign, http, ct))
+                return Results.Json(new { error = "forbidden" }, statusCode: 403);
+
+            var ok = await orgsSvc.RemoveRoleAsync(membershipId, roleName, ct);
+            if (!ok) return Results.BadRequest(new { error = "remove_failed" });
+            await memberships.RecordSecurityEventAsync("RoleChanged", userId, id, $"-{roleName}", ct);
+            return Results.NoContent();
+        }).WithName("RemoveMemberRole");
+
+        orgs.MapPost("/{id:guid}/members/{membershipId:guid}/status", async (
+            Guid id,
+            Guid membershipId,
+            MembershipStatusRequest body,
+            HttpContext http,
+            IOrganizationAdminService orgsSvc,
+            IMembershipService memberships,
+            CancellationToken ct) =>
+        {
+            if (!TryUser(http, out var userId))
+                return Results.Unauthorized();
+
+            if (!await RequirePerm(memberships, userId, id, IdentityPermissions.MemberSuspend, http, ct))
+                return Results.Json(new { error = "forbidden" }, statusCode: 403);
+
+            var ok = await orgsSvc.SetMembershipStatusAsync(membershipId, body.Status, ct);
+            if (!ok) return Results.BadRequest(new { error = "status_failed" });
+            await memberships.RecordSecurityEventAsync("UserSuspended", userId, id, body.Status, ct);
+            return Results.NoContent();
+        }).WithName("SetMembershipStatus");
+
+        return app;
+    }
+
+    static bool TryUser(HttpContext http, out Guid userId)
+    {
+        userId = default;
+        if (http.User?.Identity?.IsAuthenticated != true) return false;
+        var sub = http.User.FindFirstValue("sub") ?? http.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        return Guid.TryParse(sub, out userId);
+    }
+
+    static bool IsPlatform(HttpContext http) =>
+        http.User.Claims.Any(c =>
+            (c.Type is "role" or ClaimTypes.Role) &&
+            c.Value.Equals(IdentityRoles.PlatformAdmin, StringComparison.OrdinalIgnoreCase));
+
+    static async Task<bool> RequirePerm(
+        IMembershipService memberships, Guid userId, Guid orgId, string permission, HttpContext http, CancellationToken ct)
+    {
+        if (IsPlatform(http)) return true;
+        var snap = await memberships.GetActiveMembershipAsync(userId, orgId, ct);
+        return snap is not null &&
+               snap.Permissions.Contains(permission, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public sealed record CreateOrgRequest(string Name, string? Slug, string? Type);
+    public sealed record UpdateOrgRequest(string? Name, string? Status);
+    public sealed record RoleNameRequest(string RoleName);
+    public sealed record MembershipStatusRequest(string Status);
+}

--- a/src/Host/NotificationHub.Host/Http/SessionEndpoints.cs
+++ b/src/Host/NotificationHub.Host/Http/SessionEndpoints.cs
@@ -1,4 +1,7 @@
 using System.Security.Claims;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using NotificationHub.Core.Identity;
 
 namespace NotificationHub.Host.Http;
@@ -7,68 +10,36 @@ public static class SessionEndpoints
 {
     public static IEndpointRouteBuilder MapSessionEndpoints(this IEndpointRouteBuilder app)
     {
-        var g = app.MapGroup("/api/v1/auth/sessions").WithTags("Auth");
+        var g = app.MapGroup("/api/v1/auth").RequireAuthorization();
 
-        g.MapGet("/", async (HttpContext http, ISessionService sessions, CancellationToken ct) =>
+        g.MapGet("/sessions", async (ClaimsPrincipal user, ISessionService sessions, CancellationToken ct) =>
         {
-            if (!TryUser(http, out var userId))
+            var sub = user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (!Guid.TryParse(sub, out var userId))
                 return Results.Unauthorized();
-
-            var currentJti = http.User.FindFirstValue("jti");
             var list = await sessions.ListAsync(userId, ct);
-            // Mark current by matching stored JwtId if available — client uses IsActive + timestamps.
-            return Results.Ok(list.Select(s => new
-            {
-                id = s.Id,
-                organizationId = s.OrganizationId,
-                clientId = s.ClientId,
-                ip = s.Ip,
-                userAgent = s.UserAgent,
-                createdAt = s.CreatedAt,
-                lastSeenAt = s.LastSeenAt,
-                expiresAt = s.ExpiresAt,
-                isActive = s.IsActive
-            }));
-        }).WithName("ListSessions");
+            return Results.Ok(list);
+        });
 
-        g.MapDelete("/{sessionId:guid}", async (
-            Guid sessionId,
-            HttpContext http,
-            ISessionService sessions,
-            IMembershipService memberships,
-            CancellationToken ct) =>
+        g.MapDelete("/sessions/{sessionId:guid}", async (
+            Guid sessionId, ClaimsPrincipal user, ISessionService sessions, CancellationToken ct) =>
         {
-            if (!TryUser(http, out var userId))
+            var sub = user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (!Guid.TryParse(sub, out var userId))
                 return Results.Unauthorized();
-
             var ok = await sessions.RevokeAsync(userId, sessionId, ct);
-            if (!ok) return Results.NotFound();
-            await memberships.RecordSecurityEventAsync("SessionRevoked", userId, null, sessionId.ToString(), ct);
-            return Results.NoContent();
-        }).WithName("RevokeSession");
+            return ok ? Results.NoContent() : Results.NotFound();
+        });
 
-        g.MapPost("/revoke-all", async (
-            HttpContext http,
-            ISessionService sessions,
-            IMembershipService memberships,
-            CancellationToken ct) =>
+        g.MapDelete("/sessions", async (ClaimsPrincipal user, ISessionService sessions, CancellationToken ct) =>
         {
-            if (!TryUser(http, out var userId))
+            var sub = user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (!Guid.TryParse(sub, out var userId))
                 return Results.Unauthorized();
-
             await sessions.RevokeAllAsync(userId, ct);
-            await memberships.RecordSecurityEventAsync("SessionRevoked", userId, null, "all", ct);
             return Results.NoContent();
-        }).WithName("RevokeAllSessions");
+        });
 
         return app;
-    }
-
-    static bool TryUser(HttpContext http, out Guid userId)
-    {
-        userId = default;
-        if (http.User?.Identity?.IsAuthenticated != true) return false;
-        var sub = http.User.FindFirstValue("sub") ?? http.User.FindFirstValue(ClaimTypes.NameIdentifier);
-        return Guid.TryParse(sub, out userId);
     }
 }

--- a/src/Host/NotificationHub.Host/Http/SessionEndpoints.cs
+++ b/src/Host/NotificationHub.Host/Http/SessionEndpoints.cs
@@ -1,0 +1,74 @@
+using System.Security.Claims;
+using NotificationHub.Core.Identity;
+
+namespace NotificationHub.Host.Http;
+
+public static class SessionEndpoints
+{
+    public static IEndpointRouteBuilder MapSessionEndpoints(this IEndpointRouteBuilder app)
+    {
+        var g = app.MapGroup("/api/v1/auth/sessions").WithTags("Auth");
+
+        g.MapGet("/", async (HttpContext http, ISessionService sessions, CancellationToken ct) =>
+        {
+            if (!TryUser(http, out var userId))
+                return Results.Unauthorized();
+
+            var currentJti = http.User.FindFirstValue("jti");
+            var list = await sessions.ListAsync(userId, ct);
+            // Mark current by matching stored JwtId if available — client uses IsActive + timestamps.
+            return Results.Ok(list.Select(s => new
+            {
+                id = s.Id,
+                organizationId = s.OrganizationId,
+                clientId = s.ClientId,
+                ip = s.Ip,
+                userAgent = s.UserAgent,
+                createdAt = s.CreatedAt,
+                lastSeenAt = s.LastSeenAt,
+                expiresAt = s.ExpiresAt,
+                isActive = s.IsActive
+            }));
+        }).WithName("ListSessions");
+
+        g.MapDelete("/{sessionId:guid}", async (
+            Guid sessionId,
+            HttpContext http,
+            ISessionService sessions,
+            IMembershipService memberships,
+            CancellationToken ct) =>
+        {
+            if (!TryUser(http, out var userId))
+                return Results.Unauthorized();
+
+            var ok = await sessions.RevokeAsync(userId, sessionId, ct);
+            if (!ok) return Results.NotFound();
+            await memberships.RecordSecurityEventAsync("SessionRevoked", userId, null, sessionId.ToString(), ct);
+            return Results.NoContent();
+        }).WithName("RevokeSession");
+
+        g.MapPost("/revoke-all", async (
+            HttpContext http,
+            ISessionService sessions,
+            IMembershipService memberships,
+            CancellationToken ct) =>
+        {
+            if (!TryUser(http, out var userId))
+                return Results.Unauthorized();
+
+            await sessions.RevokeAllAsync(userId, ct);
+            await memberships.RecordSecurityEventAsync("SessionRevoked", userId, null, "all", ct);
+            return Results.NoContent();
+        }).WithName("RevokeAllSessions");
+
+        return app;
+    }
+
+    static bool TryUser(HttpContext http, out Guid userId)
+    {
+        userId = default;
+        if (http.User?.Identity?.IsAuthenticated != true) return false;
+        var sub = http.User.FindFirstValue("sub") ?? http.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        return Guid.TryParse(sub, out userId);
+    }
+}

--- a/src/Host/NotificationHub.Host/Middleware/ApiKeyAuthMiddleware.cs
+++ b/src/Host/NotificationHub.Host/Middleware/ApiKeyAuthMiddleware.cs
@@ -37,6 +37,14 @@ public sealed class ApiKeyAuthMiddleware
             return;
         }
 
+        // Human JWT path (/api/v1/auth or Authorization: Bearer) — do not require API Key.
+        // Machine clients continue to use X-Api-Key exclusively.
+        if (DualAuthPassThrough.ShouldSkipApiKey(context))
+        {
+            await _next(context);
+            return;
+        }
+
         var ip = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
         var authFailLimit = config.GetValue("RateLimiting:AuthFailuresPerMinute", 30);
 

--- a/src/Host/NotificationHub.Host/Middleware/AuthRateLimitMiddleware.cs
+++ b/src/Host/NotificationHub.Host/Middleware/AuthRateLimitMiddleware.cs
@@ -1,0 +1,42 @@
+using NotificationHub.Core.RateLimiting;
+
+namespace NotificationHub.Host.Middleware;
+
+/// <summary>
+/// Rate limits human auth-sensitive routes (invite, switch, logout, sessions).
+/// Does not affect machine API Key traffic.
+/// </summary>
+public sealed class AuthRateLimitMiddleware(RequestDelegate next, ILogger<AuthRateLimitMiddleware> log)
+{
+    static readonly string[] SensitivePrefixes =
+    [
+        "/api/v1/auth/invitations",
+        "/api/v1/auth/organizations/switch",
+        "/api/v1/auth/logout",
+        "/api/v1/auth/sessions"
+    ];
+
+    public async Task InvokeAsync(HttpContext context, IRateLimiter rateLimiter, IConfiguration config)
+    {
+        var path = context.Request.Path.Value ?? "";
+        if (!SensitivePrefixes.Any(p => path.StartsWith(p, StringComparison.OrdinalIgnoreCase)))
+        {
+            await next(context);
+            return;
+        }
+
+        var ip = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        var limit = config.GetValue("RateLimiting:AuthSensitivePerMinute", 20);
+        var key = $"auth-sensitive:ip:{ip}";
+
+        if (!await rateLimiter.IsAllowedAsync(key, limit, context.RequestAborted))
+        {
+            log.LogWarning("Auth sensitive rate limit exceeded for {IP} on {Path}", ip, path);
+            context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+            await context.Response.WriteAsJsonAsync(new { error = "Too many requests" });
+            return;
+        }
+
+        await next(context);
+    }
+}

--- a/src/Host/NotificationHub.Host/Middleware/DualAuthPassThrough.cs
+++ b/src/Host/NotificationHub.Host/Middleware/DualAuthPassThrough.cs
@@ -1,0 +1,24 @@
+namespace NotificationHub.Host.Middleware;
+
+/// <summary>
+/// Allows JWT Bearer human routes without X-Api-Key.
+/// Does not validate the JWT (JwtBearer middleware does). Does not change API Key validation for machine clients.
+/// </summary>
+public static class DualAuthPassThrough
+{
+    public static bool ShouldSkipApiKey(HttpContext context)
+    {
+        var path = context.Request.Path.Value ?? "";
+
+        // Human identity surface
+        if (path.StartsWith("/api/v1/auth", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // Bearer present → let JWT auth handle (admin routes later)
+        var auth = context.Request.Headers.Authorization.ToString();
+        if (auth.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return false;
+    }
+}

--- a/src/Host/NotificationHub.Host/NotificationHub.Host.csproj
+++ b/src/Host/NotificationHub.Host/NotificationHub.Host.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -25,7 +26,6 @@
     <ProjectReference Include="..\..\..\Plugins\Chat\NotificationHub.Plugins.Chat.Slack\NotificationHub.Plugins.Chat.Slack.csproj" />
     <ProjectReference Include="..\..\..\Plugins\Chat\NotificationHub.Plugins.Chat.WhatsApp\NotificationHub.Plugins.Chat.WhatsApp.csproj" />
     <ProjectReference Include="..\..\..\Plugins\Push\NotificationHub.Plugins.Push.Fcm\NotificationHub.Plugins.Push.Fcm.csproj" />
-  
     <ProjectReference Include="..\..\..\Plugins\Chat\NotificationHub.Plugins.Chat.Telegram\NotificationHub.Plugins.Chat.Telegram.csproj" />
     <ProjectReference Include="..\..\..\Plugins\Chat\NotificationHub.Plugins.Chat.Discord\NotificationHub.Plugins.Chat.Discord.csproj" />
     <ProjectReference Include="..\..\..\Plugins\Chat\NotificationHub.Plugins.Chat.Teams\NotificationHub.Plugins.Chat.Teams.csproj" />
@@ -44,4 +44,3 @@
     </Content>
   </ItemGroup>
 </Project>
-

--- a/src/Host/NotificationHub.Host/Security/JwtAuthExtensions.cs
+++ b/src/Host/NotificationHub.Host/Security/JwtAuthExtensions.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using NotificationHub.Core.Auth;
+using NotificationHub.Core.Identity;
+
+namespace NotificationHub.Host.Security;
+
+public static class JwtAuthExtensions
+{
+    /// <summary>
+    /// Registers JWT Bearer when Auth:JwtBearer:Enabled=true.
+    /// Does not remove or alter API Key middleware.
+    /// </summary>
+    public static IServiceCollection AddNotificationHubJwtBearer(
+        this IServiceCollection services, IConfiguration config)
+    {
+        services.Configure<JwtBearerAuthOptions>(config.GetSection(JwtBearerAuthOptions.SectionName));
+        var opts = config.GetSection(JwtBearerAuthOptions.SectionName).Get<JwtBearerAuthOptions>()
+                   ?? new JwtBearerAuthOptions();
+
+        services.AddScoped<ITenantContext, JwtTenantContext>();
+        services.AddScoped<JwtSecurityContextFactory>();
+        services.AddScoped<ISecurityContext>(sp => sp.GetRequiredService<JwtSecurityContextFactory>().Create());
+
+        if (!opts.Enabled || string.IsNullOrWhiteSpace(opts.Authority))
+        {
+            // Placeholders so DI resolves; API Key path remains primary until Identity host is up.
+            services.AddAuthentication();
+            return services;
+        }
+
+        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(o =>
+            {
+                o.Authority = opts.Authority;
+                o.Audience = opts.Audience;
+                o.RequireHttpsMetadata = opts.RequireHttpsMetadata;
+                o.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidateAudience = true,
+                    ValidateLifetime = true,
+                    ValidateIssuerSigningKey = true,
+                    NameClaimType = "sub",
+                    RoleClaimType = "role"
+                };
+            });
+
+        return services;
+    }
+}

--- a/src/Host/NotificationHub.Host/Security/JwtSecurityContext.cs
+++ b/src/Host/NotificationHub.Host/Security/JwtSecurityContext.cs
@@ -1,0 +1,50 @@
+using System.Security.Claims;
+using NotificationHub.Core.Identity;
+
+namespace NotificationHub.Host.Security;
+
+/// <summary>Builds ITenantContext / ISecurityContext from JWT principal (human path only).</summary>
+public sealed class JwtTenantContext(IHttpContextAccessor accessor) : ITenantContext
+{
+    ClaimsPrincipal? User => accessor.HttpContext?.User;
+
+    public Guid? OrganizationId => ParseGuid(User?.FindFirst("tenant_id")?.Value
+        ?? User?.FindFirst("organization_id")?.Value);
+
+    public Guid? UserId => ParseGuid(User?.FindFirst("sub")?.Value
+        ?? User?.FindFirst(ClaimTypes.NameIdentifier)?.Value);
+
+    public Guid? MembershipId => ParseGuid(User?.FindFirst("membership_id")?.Value);
+
+    static Guid? ParseGuid(string? v) => Guid.TryParse(v, out var g) ? g : null;
+}
+
+public sealed class JwtSecurityContextFactory(IHttpContextAccessor accessor)
+{
+    public ISecurityContext Create()
+    {
+        var user = accessor.HttpContext?.User;
+        if (user?.Identity?.IsAuthenticated != true)
+            return new NullSecurityContext();
+
+        var roles = user.FindAll("role").Select(c => c.Value)
+            .Concat(user.FindAll(ClaimTypes.Role).Select(c => c.Value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        // Permissions resolved server-side in later sprints; roles only in token for now.
+        var perms = user.FindAll("permission").Select(c => c.Value).ToArray();
+
+        return new SecurityContext
+        {
+            UserId = Guid.TryParse(user.FindFirst("sub")?.Value, out var uid) ? uid : null,
+            OrganizationId = Guid.TryParse(user.FindFirst("tenant_id")?.Value, out var tid) ? tid : null,
+            MembershipId = Guid.TryParse(user.FindFirst("membership_id")?.Value, out var mid) ? mid : null,
+            Roles = roles,
+            Permissions = perms,
+            IsAuthenticated = true,
+            IsPlatformUser = roles.Contains(IdentityRoles.PlatformAdmin, StringComparer.OrdinalIgnoreCase),
+            IsMfaSatisfied = user.FindAll("amr").Any(c => c.Value is "mfa" or "otp" or "pwd")
+        };
+    }
+}

--- a/src/Host/NotificationHub.Host/Security/RbacServiceCollectionExtensions.cs
+++ b/src/Host/NotificationHub.Host/Security/RbacServiceCollectionExtensions.cs
@@ -8,7 +8,7 @@ public static class RbacServiceCollectionExtensions
     public static IServiceCollection AddNotificationHubRbac(this IServiceCollection services)
     {
         services.AddSingleton<IAuthorizationPolicyProvider, PermissionPolicyProvider>();
-        services.AddSingleton<IAuthorizationHandler, PermissionAuthorizationHandler>();
+        services.AddScoped<IAuthorizationHandler, PermissionAuthorizationHandler>();
         services.AddAuthorization();
         return services;
     }

--- a/src/Host/NotificationHub.Host/Security/RbacServiceCollectionExtensions.cs
+++ b/src/Host/NotificationHub.Host/Security/RbacServiceCollectionExtensions.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Authorization;
+using NotificationHub.Core.Identity;
+
+namespace NotificationHub.Host.Security;
+
+public static class RbacServiceCollectionExtensions
+{
+    public static IServiceCollection AddNotificationHubRbac(this IServiceCollection services)
+    {
+        services.AddSingleton<IAuthorizationPolicyProvider, PermissionPolicyProvider>();
+        services.AddSingleton<IAuthorizationHandler, PermissionAuthorizationHandler>();
+        services.AddAuthorization();
+        return services;
+    }
+}

--- a/src/Host/NotificationHub.Identity/NotificationHub.Identity.csproj
+++ b/src/Host/NotificationHub.Identity/NotificationHub.Identity.csproj
@@ -6,13 +6,13 @@
     <RootNamespace>NotificationHub.Identity</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenIddict.AspNetCore" Version="6.0.0" />
-    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+    <PackageReference Include="OpenIddict.AspNetCore" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\BuildingBlocks\NotificationHub.Core\NotificationHub.Core.csproj" />

--- a/src/Host/NotificationHub.Identity/NotificationHub.Identity.csproj
+++ b/src/Host/NotificationHub.Identity/NotificationHub.Identity.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>NotificationHub.Identity</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenIddict.AspNetCore" Version="6.0.0" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\BuildingBlocks\NotificationHub.Core\NotificationHub.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Host/NotificationHub.Identity/Program.cs
+++ b/src/Host/NotificationHub.Identity/Program.cs
@@ -1,0 +1,102 @@
+using Microsoft.EntityFrameworkCore;
+using NotificationHub.Core.Persistence;
+using OpenIddict.Abstractions;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var cs = builder.Configuration.GetConnectionString("Default")
+         ?? builder.Configuration["ConnectionStrings:Default"]
+         ?? throw new InvalidOperationException("ConnectionStrings:Default required for Identity host");
+
+builder.Services.AddDbContext<NotificationDbContext>(o =>
+{
+    o.UseNpgsql(cs);
+    o.UseOpenIddict();
+});
+
+builder.Services.AddOpenIddict()
+    .AddCore(o => o.UseEntityFrameworkCore().UseDbContext<NotificationDbContext>())
+    .AddServer(o =>
+    {
+        o.SetAuthorizationEndpointUris("/connect/authorize")
+            .SetTokenEndpointUris("/connect/token")
+            .SetUserinfoEndpointUris("/connect/userinfo")
+            .SetLogoutEndpointUris("/connect/logout");
+
+        o.AllowAuthorizationCodeFlow()
+            .RequireProofKeyForCodeExchange()
+            .AllowRefreshTokenFlow()
+            .AllowClientCredentialsFlow();
+
+        o.RegisterScopes(
+            Scopes.OpenId, Scopes.Profile, Scopes.Email,
+            "notificationhub.admin");
+
+        o.AddDevelopmentEncryptionCertificate()
+            .AddDevelopmentSigningCertificate();
+
+        o.UseAspNetCore()
+            .EnableAuthorizationEndpointPassthrough()
+            .EnableTokenEndpointPassthrough()
+            .EnableUserinfoEndpointPassthrough()
+            .EnableLogoutEndpointPassthrough();
+    })
+    .AddValidation(o =>
+    {
+        o.UseLocalServer();
+        o.UseAspNetCore();
+    });
+
+builder.Services.AddAuthentication();
+builder.Services.AddAuthorization();
+builder.Services.AddControllersWithViews();
+
+var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<NotificationDbContext>();
+    await db.Database.EnsureCreatedAsync();
+    await SeedClientsAsync(scope.ServiceProvider);
+}
+
+app.UseDeveloperExceptionPage();
+app.UseRouting();
+app.UseAuthentication();
+app.UseAuthorization();
+app.MapControllers();
+app.MapGet("/", () => Results.Ok(new { service = "NotificationHub.Identity", status = "ok" }));
+
+app.Run();
+
+static async Task SeedClientsAsync(IServiceProvider sp)
+{
+    var manager = sp.GetRequiredService<IOpenIddictApplicationManager>();
+    if (await manager.FindByClientIdAsync("admin-ui") is null)
+    {
+        await manager.CreateAsync(new OpenIddictApplicationDescriptor
+        {
+            ClientId = "admin-ui",
+            DisplayName = "NotificationHub Admin UI",
+            ClientType = ClientTypes.Public,
+            ConsentType = ConsentTypes.Implicit,
+            RedirectUris = { new Uri("http://localhost:3000/api/auth/callback") },
+            PostLogoutRedirectUris = { new Uri("http://localhost:3000/") },
+            Permissions =
+            {
+                Permissions.Endpoints.Authorization,
+                Permissions.Endpoints.Token,
+                Permissions.Endpoints.Logout,
+                Permissions.GrantTypes.AuthorizationCode,
+                Permissions.GrantTypes.RefreshToken,
+                Permissions.ResponseTypes.Code,
+                Permissions.Scopes.Email,
+                Permissions.Scopes.Profile,
+                Permissions.Scopes.Roles,
+                Permissions.Prefixes.Scope + "notificationhub.admin"
+            },
+            Requirements = { Requirements.Features.ProofKeyForCodeExchange }
+        });
+    }
+}

--- a/src/Host/NotificationHub.Identity/Signing/JwksDocument.cs
+++ b/src/Host/NotificationHub.Identity/Signing/JwksDocument.cs
@@ -1,0 +1,43 @@
+using System.Security.Cryptography;
+using System.Text.Json.Serialization;
+
+namespace NotificationHub.Identity.Signing;
+
+public sealed class JwksDocument
+{
+    [JsonPropertyName("keys")]
+    public List<Jwk> Keys { get; set; } = [];
+}
+
+public sealed class Jwk
+{
+    [JsonPropertyName("kty")] public string Kty { get; set; } = "RSA";
+    [JsonPropertyName("use")] public string Use { get; set; } = "sig";
+    [JsonPropertyName("kid")] public string Kid { get; set; } = "";
+    [JsonPropertyName("alg")] public string Alg { get; set; } = "RS256";
+    [JsonPropertyName("n")] public string N { get; set; } = "";
+    [JsonPropertyName("e")] public string E { get; set; } = "";
+}
+
+public static class RsaJwksFactory
+{
+    public static JwksDocument FromRsa(RSA rsa, string keyId)
+    {
+        var p = rsa.ExportParameters(false);
+        return new JwksDocument
+        {
+            Keys =
+            [
+                new Jwk
+                {
+                    Kid = keyId,
+                    N = Base64Url(p.Modulus!),
+                    E = Base64Url(p.Exponent!)
+                }
+            ]
+        };
+    }
+
+    static string Base64Url(byte[] data) =>
+        Convert.ToBase64String(data).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+}

--- a/src/Host/NotificationHub.Identity/Signing/SigningKeyOptions.cs
+++ b/src/Host/NotificationHub.Identity/Signing/SigningKeyOptions.cs
@@ -1,0 +1,19 @@
+namespace NotificationHub.Identity.Signing;
+
+/// <summary>
+/// Signing key configuration for OpenIddict / JWT (A2.7 JWKS readiness).
+/// Production: load RSA from Key Vault / file; Development: ephemeral RSA.
+/// </summary>
+public sealed class SigningKeyOptions
+{
+    public const string SectionName = "Identity:Signing";
+
+    /// <summary>PEM or base64 RSA private key. Empty → generate ephemeral (dev only).</summary>
+    public string? RsaPrivateKeyPem { get; set; }
+
+    /// <summary>Key id exposed on JWKS.</summary>
+    public string KeyId { get; set; } = "nh-signing-1";
+
+    /// <summary>When true, host exposes /.well-known/jwks.json for API validation.</summary>
+    public bool ExposeJwks { get; set; } = true;
+}

--- a/src/Host/NotificationHub.Identity/appsettings.Development.json
+++ b/src/Host/NotificationHub.Identity/appsettings.Development.json
@@ -1,0 +1,10 @@
+{
+  "ConnectionStrings": {
+    "Default": "Host=localhost;Port=5432;Database=notificationhub;Username=postgres;Password=postgres"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug"
+    }
+  }
+}

--- a/src/Host/NotificationHub.Identity/appsettings.json
+++ b/src/Host/NotificationHub.Identity/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "ConnectionStrings": {
+    "Default": ""
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/tests/Unit/NotificationHub.Core.Tests/Identity/MembershipIsolationTests.cs
+++ b/tests/Unit/NotificationHub.Core.Tests/Identity/MembershipIsolationTests.cs
@@ -1,0 +1,26 @@
+using NotificationHub.Core.Identity;
+
+namespace NotificationHub.Core.Tests.Identity;
+
+/// <summary>Regression placeholders — expand with Testcontainers/EF InMemory in CI.</summary>
+public class MembershipIsolationTests
+{
+    [Fact]
+    public void Permission_names_are_resource_dot_action()
+    {
+        foreach (var p in IdentityPermissions.All)
+            Assert.Contains('.', p);
+    }
+
+    [Fact]
+    public void PlatformAdmin_role_name_is_stable()
+    {
+        Assert.Equal("PlatformAdmin", IdentityRoles.PlatformAdmin);
+    }
+
+    [Fact]
+    public void OrganizationAdmin_cannot_be_confused_with_PlatformAdmin()
+    {
+        Assert.NotEqual(IdentityRoles.OrganizationAdmin, IdentityRoles.PlatformAdmin);
+    }
+}


### PR DESCRIPTION
## Summary

Implements B2B multi-tenant identity (Organization + membership lifecycle), JWT alongside existing API Key (unchanged), RBAC permissions, and human-centered Admin UI aligned to API contracts.

## Backend
- ADR-019 + backlog
- Domain: Organization, User, Membership, Roles, Permissions, Invitations, Sessions
- Identity host (OpenIddict) + JWT Bearer on API Host
- `/api/v1/auth/*` and `/api/v1/organizations/*`
- Dual-auth: API Key for machines; Bearer for humans

## Admin (`apps/admin`)
- OIDC Auth Code + PKCE
- Org switch, members, sessions, settings
- UX overhaul: guided send/campaign flows, no JSON-first UI

## Notes
- API Key system intentionally untouched
- Program.cs wire-up docs under `docs/ops/`
- OpenAPI freeze: `docs/openapi/identity-v1-freeze.md`

## Test plan
- [ ] `dotnet restore` / build Identity + Host
- [ ] Auth endpoints with JWT
- [ ] API Key machine path regression
- [ ] Admin login / switch org / members