### PR TITLE
fix(auth): JWT users get 401 on /templates — bridge AuthContext

### DIFF
--- a/src/Host/NotificationHub.Host/Middleware/JwtAuthContextMiddleware.cs
+++ b/src/Host/NotificationHub.Host/Middleware/JwtAuthContextMiddleware.cs
@@ -1,0 +1,67 @@
+using System.Security.Claims;
+using NotificationHub.Abstractions.Models;
+
+namespace NotificationHub.Host.Middleware;
+
+/// <summary>
+/// After JwtBearer authentication, populate <see cref="AuthContext"/> so endpoint
+/// <c>RequireRoles</c> works for human JWT clients the same way as API keys.
+/// API-key AuthContext (set by <see cref="ApiKeyAuthMiddleware"/>) is left untouched.
+/// </summary>
+public sealed class JwtAuthContextMiddleware(RequestDelegate next)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (context.Items.ContainsKey(ApiKeyAuthMiddleware.AuthContextItem))
+        {
+            await next(context);
+            return;
+        }
+
+        var user = context.User;
+        if (user.Identity?.IsAuthenticated == true)
+        {
+            var roles = user.FindAll("role")
+                .Concat(user.FindAll(ClaimTypes.Role))
+                .Select(c => c.Value)
+                .Where(v => !string.IsNullOrWhiteSpace(v))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            var tenant = user.FindFirst("tenant_id")?.Value
+                         ?? user.FindFirst("organization_id")?.Value;
+
+            // Map identity roles to legacy AppRoles so HasAnyRole(Admin/Sender/Reader) works
+            var mapped = new HashSet<string>(roles, StringComparer.OrdinalIgnoreCase);
+            if (roles.Any(r => r is "SuperAdmin" or "PlatformAdmin" or "OrganizationOwner" or "OrganizationAdmin"))
+            {
+                mapped.Add(AppRoles.Admin);
+                mapped.Add(AppRoles.Sender);
+                mapped.Add(AppRoles.Reader);
+            }
+            else if (roles.Any(r => r is "NotificationOperator"))
+            {
+                mapped.Add(AppRoles.Sender);
+                mapped.Add(AppRoles.Reader);
+            }
+            else if (roles.Any(r => r is "Viewer" or "Auditor"))
+            {
+                mapped.Add(AppRoles.Reader);
+            }
+
+            context.Items[ApiKeyAuthMiddleware.AuthContextItem] = new AuthContext
+            {
+                ApiKeyId = Guid.Empty,
+                TenantId = tenant,
+                Roles = mapped.ToArray(),
+                KeyName = user.FindFirst("name")?.Value
+                          ?? user.FindFirst(ClaimTypes.Email)?.Value
+                          ?? user.FindFirst("sub")?.Value
+                          ?? "jwt",
+                IsJwt = true
+            };
+        }
+
+        await next(context);
+    }
+}

--- a/src/Host/NotificationHub.Host/Program.cs
+++ b/src/Host/NotificationHub.Host/Program.cs
@@ -497,6 +497,8 @@ app.UseMiddleware<AdminIpAllowlistMiddleware>();
 // AuthN (API key) — equivalent to UseAuthentication for this API
 app.UseAuthentication();
 app.UseMiddleware<ApiKeyAuthMiddleware>();
+// Bridge JWT principal → AuthContext for RequireRoles on domain endpoints
+app.UseMiddleware<JwtAuthContextMiddleware>();
 app.UseAuthorization();
 // AuthZ: RequireRoles on endpoints + AuthorizationBehavior on MediatR commands
 

--- a/src/Kernel/NotificationHub.Abstractions/Models/SecurityModels.cs
+++ b/src/Kernel/NotificationHub.Abstractions/Models/SecurityModels.cs
@@ -54,8 +54,10 @@ public sealed class AuthContext
 
     public bool HasAnyRole(params string[] roles)
     {
-        if (IsAdmin) return true;
-        if (roles.Any(HasRole)) return true;
+        if (IsAdmin)
+            return true;
+        if (roles.Any(HasRole))
+            return true;
         // Map identity roles → legacy AppRoles expected by endpoints
         foreach (var r in Roles)
         {

--- a/src/Kernel/NotificationHub.Abstractions/Models/SecurityModels.cs
+++ b/src/Kernel/NotificationHub.Abstractions/Models/SecurityModels.cs
@@ -37,8 +37,39 @@ public sealed class AuthContext
     public string? TenantId { get; init; }
     public IReadOnlyList<string> Roles { get; init; } = [];
     public string KeyName { get; init; } = "";
+    /// <summary>True when authenticated via JWT (human) rather than API key (machine).</summary>
+    public bool IsJwt { get; init; }
 
-    public bool IsAdmin => Roles.Contains(AppRoles.Admin, StringComparer.OrdinalIgnoreCase);
+    /// <summary>
+    /// Admin for API-key role "admin" or platform/org identity roles (SuperAdmin, PlatformAdmin, Organization*).
+    /// </summary>
+    public bool IsAdmin =>
+        Roles.Contains(AppRoles.Admin, StringComparer.OrdinalIgnoreCase)
+        || Roles.Any(r => string.Equals(r, "SuperAdmin", StringComparison.OrdinalIgnoreCase)
+                          || string.Equals(r, "PlatformAdmin", StringComparison.OrdinalIgnoreCase)
+                          || string.Equals(r, "OrganizationOwner", StringComparison.OrdinalIgnoreCase)
+                          || string.Equals(r, "OrganizationAdmin", StringComparison.OrdinalIgnoreCase));
+
     public bool HasRole(string role) => IsAdmin || Roles.Contains(role, StringComparer.OrdinalIgnoreCase);
-    public bool HasAnyRole(params string[] roles) => IsAdmin || roles.Any(HasRole);
+
+    public bool HasAnyRole(params string[] roles)
+    {
+        if (IsAdmin) return true;
+        if (roles.Any(HasRole)) return true;
+        // Map identity roles → legacy AppRoles expected by endpoints
+        foreach (var r in Roles)
+        {
+            if (string.Equals(r, "NotificationOperator", StringComparison.OrdinalIgnoreCase)
+                && roles.Any(x => string.Equals(x, AppRoles.Sender, StringComparison.OrdinalIgnoreCase)
+                               || string.Equals(x, AppRoles.Reader, StringComparison.OrdinalIgnoreCase)))
+                return true;
+            if (string.Equals(r, "Viewer", StringComparison.OrdinalIgnoreCase)
+                && roles.Any(x => string.Equals(x, AppRoles.Reader, StringComparison.OrdinalIgnoreCase)))
+                return true;
+            if (string.Equals(r, "Auditor", StringComparison.OrdinalIgnoreCase)
+                && roles.Any(x => string.Equals(x, AppRoles.Reader, StringComparison.OrdinalIgnoreCase)))
+                return true;
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
## Symptom
Login /auth/me /organizations = 200, but GET/POST /api/v1/templates = **401** even with Bearer token.

## Cause
`RequireRoles` only checks `AuthContext` set by API-key middleware. JWT path skipped API key and never set AuthContext → Unauthorized.

## Fix
`JwtAuthContextMiddleware` after authentication maps JWT role/tenant claims into AuthContext and maps SuperAdmin/org roles → admin/sender/reader.