### PR TITLE
fix(admin): re-login race — stale refresh wiping new session

### DIFF
--- a/apps/admin/app/login/page.tsx
+++ b/apps/admin/app/login/page.tsx
@@ -1,15 +1,20 @@
 'use client'
 
 import { useState, Suspense } from 'react'
-import { useSearchParams, useRouter } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { identityApi } from '@/lib/api/identity'
-import { setSession, safeReturnPath, tenantFromAccessToken } from '@/lib/auth/session'
+import {
+  setSession,
+  clearSession,
+  safeReturnPath,
+  tenantFromAccessToken,
+  setAuthBootstrapLock,
+} from '@/lib/auth/session'
 import { ApiError } from '@/lib/api/errors'
 
 function LoginInner() {
   const params = useSearchParams()
-  const router = useRouter()
   const next = safeReturnPath(params.get('next'), '/dashboard')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -23,6 +28,13 @@ function LoginInner() {
     e.preventDefault()
     setBusy(true)
     setError(null)
+
+    // Stop AuthProvider / 401 handlers from wiping tokens during this flow
+    setAuthBootstrapLock(true)
+    // Drop stale refresh tokens so a parallel refresh cannot race login
+    clearSession()
+    setAuthBootstrapLock(true)
+
     try {
       const tokens =
         mode === 'login'
@@ -35,18 +47,27 @@ function LoginInner() {
               organizationName: orgName.trim() || undefined,
             })
 
-      if (!tokens?.accessToken) {
+      const accessToken = tokens?.accessToken
+      const refreshToken = tokens?.refreshToken
+      if (!accessToken) {
         setError('Server did not return an access token')
+        setAuthBootstrapLock(false)
         return
       }
 
       setSession({
-        accessToken: tokens.accessToken,
-        refreshToken: tokens.refreshToken,
-        tenantId: tokens.organizationId ?? tenantFromAccessToken(tokens.accessToken),
+        accessToken,
+        refreshToken,
+        tenantId:
+          tokens.organizationId ??
+          (typeof tokens.organizationId === 'string' ? tokens.organizationId : undefined) ??
+          tenantFromAccessToken(accessToken),
       })
-      router.replace(next)
+
+      // Hard navigation so middleware sees nh_auth cookie and memory/storage are consistent
+      window.location.assign(next)
     } catch (err) {
+      setAuthBootstrapLock(false)
       if (err instanceof ApiError) {
         const map: Record<string, string> = {
           invalid_credentials: 'Email or password is incorrect',

--- a/apps/admin/lib/api/client.ts
+++ b/apps/admin/lib/api/client.ts
@@ -6,6 +6,7 @@ import {
   getTenantId,
   setSession,
   clearSession,
+  isAuthBootstrapLocked,
 } from '@/lib/auth/session'
 
 export interface ApiRequestOptions extends Omit<RequestInit, 'body'> {
@@ -54,7 +55,7 @@ async function tryRefresh(): Promise<string | undefined> {
       cache: 'no-store',
     })
     if (!response.ok) {
-      clearSession()
+      if (!isAuthBootstrapLocked()) clearSession()
       return undefined
     }
     const data = (await response.json()) as {
@@ -66,13 +67,13 @@ async function tryRefresh(): Promise<string | undefined> {
     const accessToken = data.accessToken ?? data.AccessToken
     const refreshToken = data.refreshToken ?? data.RefreshToken
     if (!accessToken) {
-      clearSession()
+      if (!isAuthBootstrapLocked()) clearSession()
       return undefined
     }
     setSession({ accessToken, refreshToken: refreshToken ?? rt })
     return accessToken
   } catch {
-    clearSession()
+    if (!isAuthBootstrapLocked()) clearSession()
     return undefined
   }
 }
@@ -109,7 +110,7 @@ export async function request<T>(path: string, options: ApiRequestOptions = {}):
     if (next) {
       return request<T>(path, { ...options, accessToken: next, _retried: true })
     }
-    clearSession()
+    if (!isAuthBootstrapLocked()) clearSession()
     if (typeof window !== 'undefined' && !path.includes('/auth/login') && !path.includes('/auth/refresh')) {
       const nextPath = window.location.pathname + window.location.search
       if (!window.location.pathname.startsWith('/login')) {

--- a/apps/admin/lib/auth/session.ts
+++ b/apps/admin/lib/auth/session.ts
@@ -1,12 +1,12 @@
 /**
  * Session storage strategy (SPA, pre-BFF):
- * - Access token: in-memory only (not durable across full page reloads until refresh).
- * - Refresh token + tenant + PKCE: sessionStorage (tab-scoped, not shared across tabs/origins as freely as localStorage).
+ * - Access + refresh tokens: sessionStorage (tab-scoped).
  * - Auth presence cookie (non-secret): lets edge middleware redirect unauthenticated users.
  *
  * Production target: BFF with httpOnly Secure SameSite cookies.
  */
 
+const ACCESS_TOKEN_KEY = 'nh.at'
 const REFRESH_TOKEN_KEY = 'nh.rt'
 const TENANT_ID_KEY = 'nh.tid'
 const PKCE_VERIFIER_KEY = 'nh.pkce'
@@ -14,6 +14,8 @@ const OIDC_STATE_KEY = 'nh.oidc_state'
 const AUTH_MARKER = 'nh_auth'
 
 let memoryAccessToken: string | undefined
+/** Prevents AuthProvider refresh from clearing a login that just succeeded. */
+let authBootstrapLock = false
 
 function ss(): Storage | null {
   if (typeof window === 'undefined') return null
@@ -34,8 +36,19 @@ function setAuthMarker(on: boolean) {
   }
 }
 
+export function setAuthBootstrapLock(locked: boolean) {
+  authBootstrapLock = locked
+}
+
+export function isAuthBootstrapLocked() {
+  return authBootstrapLock
+}
+
 export function getAccessToken(): string | undefined {
-  return memoryAccessToken
+  if (memoryAccessToken) return memoryAccessToken
+  const fromStore = ss()?.getItem(ACCESS_TOKEN_KEY) ?? undefined
+  if (fromStore) memoryAccessToken = fromStore
+  return fromStore
 }
 
 export function getRefreshToken(): string | undefined {
@@ -51,26 +64,27 @@ export function setSession(input: {
   refreshToken?: string
   tenantId?: string
 }) {
+  const store = ss()
   if (input.accessToken) {
     memoryAccessToken = input.accessToken
     setAuthMarker(true)
+    store?.setItem(ACCESS_TOKEN_KEY, input.accessToken)
   }
-  const store = ss()
-  if (!store) return
-  if (input.refreshToken) store.setItem(REFRESH_TOKEN_KEY, input.refreshToken)
-  if (input.tenantId) store.setItem(TENANT_ID_KEY, input.tenantId)
+  if (input.refreshToken) store?.setItem(REFRESH_TOKEN_KEY, input.refreshToken)
+  if (input.tenantId) store?.setItem(TENANT_ID_KEY, input.tenantId)
 }
 
 export function clearSession() {
+  if (authBootstrapLock) return
   memoryAccessToken = undefined
   setAuthMarker(false)
   const store = ss()
   if (!store) return
+  store.removeItem(ACCESS_TOKEN_KEY)
   store.removeItem(REFRESH_TOKEN_KEY)
   store.removeItem(TENANT_ID_KEY)
   store.removeItem(PKCE_VERIFIER_KEY)
   store.removeItem(OIDC_STATE_KEY)
-  // purge legacy localStorage keys if present
   try {
     window.localStorage.removeItem('notificationhub.accessToken')
     window.localStorage.removeItem('notificationhub.refreshToken')
@@ -119,4 +133,11 @@ export function tenantFromAccessToken(accessToken?: string): string | undefined 
   } catch {
     return undefined
   }
+}
+
+export function isPublicAuthPath(pathname?: string): boolean {
+  const p = pathname ?? (typeof window !== 'undefined' ? window.location.pathname : '')
+  return ['/login', '/auth/callback', '/auth/accept-invite'].some(
+    (x) => p === x || p.startsWith(`${x}/`),
+  )
 }

--- a/apps/admin/providers/auth-provider.tsx
+++ b/apps/admin/providers/auth-provider.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { usePathname } from 'next/navigation'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { identityApi, type AuthMe, type OrgMembership } from '@/lib/api/identity'
 import {
@@ -8,6 +9,8 @@ import {
   getRefreshToken,
   setSession,
   clearSession,
+  isPublicAuthPath,
+  isAuthBootstrapLocked,
 } from '@/lib/auth/session'
 import { hasPermission } from '@/lib/auth/permissions'
 
@@ -28,43 +31,55 @@ const AuthContext = createContext<AuthContextValue | null>(null)
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [tokenReady, setTokenReady] = useState(false)
   const queryClient = useQueryClient()
+  const pathname = usePathname()
+  const onPublic = isPublicAuthPath(pathname)
 
   useEffect(() => {
     void (async () => {
+      // On login/register pages never auto-refresh or clearSession — avoids racing the form submit.
+      if (onPublic || isAuthBootstrapLocked()) {
+        setTokenReady(true)
+        return
+      }
+
       if (!getAccessToken()) {
         const rt = getRefreshToken()
         if (rt) {
           try {
             const tokens = await identityApi.refresh(rt)
-            setSession({
-              accessToken: tokens.accessToken,
-              refreshToken: tokens.refreshToken,
-            })
+            if (tokens?.accessToken) {
+              setSession({
+                accessToken: tokens.accessToken,
+                refreshToken: tokens.refreshToken ?? rt,
+              })
+            }
           } catch {
-            clearSession()
+            if (!isAuthBootstrapLocked()) clearSession()
           }
         }
       }
       setTokenReady(true)
     })()
-  }, [])
+  }, [onPublic])
+
+  const hasToken = tokenReady && !!getAccessToken()
 
   const meQuery = useQuery({
     queryKey: ['auth', 'me'],
     queryFn: () => identityApi.me(),
-    enabled: tokenReady && !!getAccessToken(),
+    enabled: !onPublic && hasToken,
     retry: false,
   })
 
   const orgsQuery = useQuery({
     queryKey: ['auth', 'organizations'],
     queryFn: () => identityApi.organizations(),
-    enabled: tokenReady && !!getAccessToken(),
+    enabled: !onPublic && hasToken,
     retry: false,
   })
 
-  const login = useCallback((_returnTo?: string) => {
-    const next = _returnTo ?? '/dashboard'
+  const login = useCallback((returnTo?: string) => {
+    const next = returnTo ?? '/dashboard'
     window.location.href = `/login?next=${encodeURIComponent(next)}`
   }, [])
 
@@ -109,7 +124,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     () => ({
       me: meQuery.data,
       organizations: orgsQuery.data ?? [],
-      isLoading: !tokenReady || meQuery.isLoading || orgsQuery.isLoading,
+      isLoading: !tokenReady || (!onPublic && hasToken && (meQuery.isLoading || orgsQuery.isLoading)),
       isAuthenticated: !!getAccessToken() && !!meQuery.data,
       can,
       login,
@@ -117,7 +132,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       switchOrganization,
       refreshMe,
     }),
-    [meQuery.data, meQuery.isLoading, orgsQuery.data, orgsQuery.isLoading, tokenReady, can, login, logout, switchOrganization, refreshMe],
+    [
+      meQuery.data,
+      meQuery.isLoading,
+      orgsQuery.data,
+      orgsQuery.isLoading,
+      tokenReady,
+      onPublic,
+      hasToken,
+      can,
+      login,
+      logout,
+      switchOrganization,
+      refreshMe,
+    ],
   )
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>


### PR DESCRIPTION
## Problem
Server returned **200** on `POST /api/v1/auth/login` (and refresh/me succeeded), but the admin UI showed **Email or password is incorrect** on re-login.

## Root cause
On `/login`, `AuthProvider` auto-called `/auth/refresh` with a **stale refresh token** from a previous session. That race could `clearSession()` while the new login was in flight, or leave the UI in a bad state despite a successful login.

Access token was **memory-only**, so navigation made the client rely on refresh and amplified the race.

## Fix
- Persist access token in `sessionStorage`
- Skip AuthProvider bootstrap refresh on public routes (`/login`, …)
- Login flow: bootstrap lock + clear stale tokens before submit + hard redirect after success
- `clearSession` no-ops while login lock is held
