### PR TITLE
fix(auth): first-attempt login 401 for good

### DIFF
--- a/apps/admin/app/login/page.tsx
+++ b/apps/admin/app/login/page.tsx
@@ -28,10 +28,8 @@ function LoginInner() {
     setBusy(true)
     setError(null)
 
-    // Stop AuthProvider / 401 handlers from wiping tokens during this flow
-    setAuthBootstrapLock(true)
-    // Drop stale refresh tokens so a parallel refresh cannot race login
-    clearSession()
+    // Drop any stale tokens first (force), then lock so parallel refresh cannot wipe a new session
+    clearSession(true)
     setAuthBootstrapLock(true)
 
     try {

--- a/apps/admin/lib/auth/session.ts
+++ b/apps/admin/lib/auth/session.ts
@@ -73,8 +73,8 @@ export function setSession(input: {
   }
 }
 
-export function clearSession() {
-  if (authBootstrapLock) return
+export function clearSession(force = false) {
+  if (authBootstrapLock && !force) return
   memoryAccessToken = undefined
   setAuthMarker(false)
   const store = ss()

--- a/src/Host/NotificationHub.Host/Auth/AccountAuthEndpoints.cs
+++ b/src/Host/NotificationHub.Host/Auth/AccountAuthEndpoints.cs
@@ -9,8 +9,11 @@ public static class AccountAuthEndpoints
     {
         var g = app.MapGroup("/api/v1/auth").WithTags("Auth");
 
-        g.MapPost("/register", async (RegisterRequest body, AccountAuthService auth, CancellationToken ct) =>
+        g.MapPost("/register", async (RegisterRequest? body, AccountAuthService auth, CancellationToken ct) =>
         {
+            if (body is null || string.IsNullOrWhiteSpace(body.Email) || string.IsNullOrWhiteSpace(body.Password))
+                return Results.BadRequest(new { error = "invalid_input" });
+
             var (ok, error, tokens) = await auth.RegisterAsync(
                 body.Email, body.Password, body.DisplayName,
                 body.CreateOrganization ?? true, body.OrganizationName, ct);
@@ -19,17 +22,25 @@ public static class AccountAuthEndpoints
             return Results.Ok(tokens);
         }).AllowAnonymous().WithName("AuthRegister");
 
-        g.MapPost("/login", async (LoginRequest body, AccountAuthService auth, CancellationToken ct) =>
+        g.MapPost("/login", async (LoginRequest? body, AccountAuthService auth, ILoggerFactory lf, CancellationToken ct) =>
         {
+            if (body is null || string.IsNullOrWhiteSpace(body.Email) || string.IsNullOrWhiteSpace(body.Password))
+                return Results.Json(new { error = "invalid_input" }, statusCode: StatusCodes.Status400BadRequest);
+
             var (ok, error, tokens) = await auth.LoginAsync(
                 body.Email, body.Password, body.OrganizationId, ct);
             if (!ok)
-                return Results.Json(new { error }, statusCode: StatusCodes.Status401Unauthorized);
+            {
+                lf.CreateLogger("AuthLogin").LogInformation("Login failed for {Email}: {Error}", body.Email, error);
+                return Results.Json(new { error = error ?? "invalid_credentials" }, statusCode: StatusCodes.Status401Unauthorized);
+            }
             return Results.Ok(tokens);
         }).AllowAnonymous().WithName("AuthLogin");
 
-        g.MapPost("/refresh", async (RefreshRequest body, AccountAuthService auth, CancellationToken ct) =>
+        g.MapPost("/refresh", async (RefreshRequest? body, AccountAuthService auth, CancellationToken ct) =>
         {
+            if (body is null || string.IsNullOrWhiteSpace(body.RefreshToken))
+                return Results.Unauthorized();
             var (ok, tokens) = await auth.RefreshAsync(body.RefreshToken, ct);
             if (!ok || tokens is null)
                 return Results.Unauthorized();

--- a/src/Host/NotificationHub.Host/Auth/AccountAuthService.cs
+++ b/src/Host/NotificationHub.Host/Auth/AccountAuthService.cs
@@ -102,13 +102,27 @@ public sealed class AccountAuthService(
         string email, string password, Guid? organizationId, CancellationToken ct)
     {
         email = email.Trim().ToLowerInvariant();
-        var user = await db.Set<IdentityUserEntity>().FirstOrDefaultAsync(u => u.Email == email, ct);
+        // Case-insensitive email match (unique index is on lower("Email"))
+        var user = await db.Set<IdentityUserEntity>()
+            .FirstOrDefaultAsync(u => u.Email.ToLower() == email, ct);
         if (user is null || string.IsNullOrEmpty(user.PasswordHash))
+        {
+            log.LogDebug("Login miss: user not found or empty password hash for {Email}", email);
             return (false, "invalid_credentials", null);
+        }
 
         var verify = _hasher.VerifyHashedPassword(user, user.PasswordHash, password);
         if (verify == PasswordVerificationResult.Failed)
+        {
+            log.LogDebug("Login miss: bad password for {Email}", email);
             return (false, "invalid_credentials", null);
+        }
+        if (verify == PasswordVerificationResult.SuccessRehashNeeded)
+        {
+            user.PasswordHash = _hasher.HashPassword(user, password);
+            user.UpdatedAt = DateTimeOffset.UtcNow;
+            await db.SaveChangesAsync(ct);
+        }
 
         if (!string.Equals(user.Status, "Active", StringComparison.OrdinalIgnoreCase))
             return (false, "user_inactive", null);
@@ -299,12 +313,30 @@ public static class SuperAdminSeeder
             {
                 Email = email,
                 DisplayName = opts.DisplayName,
-                Status = "Active"
+                Status = "Active",
+                CreatedAt = DateTimeOffset.UtcNow,
+                UpdatedAt = DateTimeOffset.UtcNow
             };
             user.PasswordHash = hasher.HashPassword(user, opts.Password);
             db.Set<IdentityUserEntity>().Add(user);
             await db.SaveChangesAsync(ct);
             log.LogWarning("Seeded SuperAdmin user — change password immediately");
+        }
+        else
+        {
+            // Keep bootstrap password in sync with configuration so first login always works
+            // after reseeds / config changes (empty hash, rotated Auth:SuperAdmin:Password, etc.).
+            var needsHash = string.IsNullOrEmpty(user.PasswordHash);
+            var mismatch = !needsHash
+                && hasher.VerifyHashedPassword(user, user.PasswordHash!, opts.Password) == PasswordVerificationResult.Failed;
+            if (needsHash || mismatch)
+            {
+                user.PasswordHash = hasher.HashPassword(user, opts.Password);
+                user.Status = "Active";
+                user.UpdatedAt = DateTimeOffset.UtcNow;
+                await db.SaveChangesAsync(ct);
+                log.LogWarning("Re-synced SuperAdmin password hash from Auth:SuperAdmin configuration");
+            }
         }
 
         var role = await db.Set<IdentityRoleEntity>()

--- a/src/Host/NotificationHub.Host/Middleware/DualAuthPassThrough.cs
+++ b/src/Host/NotificationHub.Host/Middleware/DualAuthPassThrough.cs
@@ -6,15 +6,32 @@ namespace NotificationHub.Host.Middleware;
 /// </summary>
 public static class DualAuthPassThrough
 {
+    static readonly string[] AnonymousAuthExact =
+    [
+        "/api/v1/auth/login",
+        "/api/v1/auth/register",
+        "/api/v1/auth/refresh"
+    ];
+
+    public static bool IsAnonymousAuthPath(string path)
+    {
+        foreach (var p in AnonymousAuthExact)
+        {
+            if (path.Equals(p, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
     public static bool ShouldSkipApiKey(HttpContext context)
     {
         var path = context.Request.Path.Value ?? "";
 
-        // Human identity surface
+        // Entire human identity surface (login/register/refresh/me/orgs/sessions/…)
         if (path.StartsWith("/api/v1/auth", StringComparison.OrdinalIgnoreCase))
             return true;
 
-        // Bearer present → let JWT auth handle (admin routes later)
+        // Bearer present → let JWT auth handle
         var auth = context.Request.Headers.Authorization.ToString();
         if (auth.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
             return true;

--- a/src/Host/NotificationHub.Host/Program.cs
+++ b/src/Host/NotificationHub.Host/Program.cs
@@ -496,6 +496,7 @@ app.UseMiddleware<AdminIpAllowlistMiddleware>();
 
 // AuthN (API key) — equivalent to UseAuthentication for this API
 app.UseAuthentication();
+app.UseMiddleware<AuthRateLimitMiddleware>();
 app.UseMiddleware<ApiKeyAuthMiddleware>();
 // Bridge JWT principal → AuthContext for RequireRoles on domain endpoints
 app.UseMiddleware<JwtAuthContextMiddleware>();

--- a/src/Host/NotificationHub.Host/Security/JwtAuthExtensions.cs
+++ b/src/Host/NotificationHub.Host/Security/JwtAuthExtensions.cs
@@ -1,29 +1,24 @@
 using System.Text;
+using System.Security.Cryptography;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.IdentityModel.Tokens;
 using NotificationHub.Core.Auth;
 using NotificationHub.Core.Identity;
 using NotificationHub.Host.Auth;
+using NotificationHub.Host.Middleware;
 
 namespace NotificationHub.Host.Security;
 
 public static class JwtAuthExtensions
 {
-    /// <summary>
-    /// JWT Bearer for human clients. API Key middleware remains for machine clients.
-    /// Supports local HS256 (Auth:Jwt) and optional external Authority (Auth:JwtBearer).
-    /// </summary>
-    public static IServiceCollection AddNotificationHubJwtBearer(
-        this IServiceCollection services, IConfiguration config)
+    public static IServiceCollection AddNotificationHubJwtBearer(this IServiceCollection services, IConfiguration config)
     {
-        services.Configure<JwtBearerAuthOptions>(config.GetSection(JwtBearerAuthOptions.SectionName));
         services.Configure<JwtTokenOptions>(config.GetSection(JwtTokenOptions.SectionName));
+        services.Configure<JwtBearerAuthOptions>(config.GetSection(JwtBearerAuthOptions.SectionName));
         services.Configure<SuperAdminSeedOptions>(config.GetSection(SuperAdminSeedOptions.SectionName));
-
-        services.AddScoped<ITenantContext, JwtTenantContext>();
-        services.AddScoped<JwtSecurityContextFactory>();
-        services.AddScoped<ISecurityContext>(sp => sp.GetRequiredService<JwtSecurityContextFactory>().Create());
+        services.AddSingleton<JwtSecurityContextFactory>();
+        services.AddScoped(sp => sp.GetRequiredService<JwtSecurityContextFactory>().Create());
         services.AddScoped<AccountAuthService>();
 
         var local = config.GetSection(JwtTokenOptions.SectionName).Get<JwtTokenOptions>() ?? new JwtTokenOptions();
@@ -52,13 +47,19 @@ public static class JwtAuthExtensions
                     NameClaimType = "sub",
                     RoleClaimType = "role"
                 };
+                o.Events = AnonymousAuthJwtEvents();
             });
         }
         else
         {
-            var keyBytes = Encoding.UTF8.GetBytes(local.SigningKey);
+            // MUST match AccountAuthService.IssueTokensAsync key derivation
+            var keyBytes = Encoding.UTF8.GetBytes(local.SigningKey ?? string.Empty);
             if (keyBytes.Length < 32)
-                keyBytes = System.Security.Cryptography.SHA256.HashData(keyBytes);
+                keyBytes = SHA256.HashData(keyBytes.Length == 0
+                    ? "NotificationHub.DevSigningKey"u8.ToArray()
+                    : keyBytes);
+            else if (keyBytes.Length > 64)
+                keyBytes = keyBytes.AsSpan(0, 64).ToArray();
 
             auth.AddJwtBearer(o =>
             {
@@ -75,6 +76,7 @@ public static class JwtAuthExtensions
                     RoleClaimType = "role",
                     ClockSkew = TimeSpan.FromMinutes(1)
                 };
+                o.Events = AnonymousAuthJwtEvents();
             });
         }
 
@@ -84,4 +86,28 @@ public static class JwtAuthExtensions
 
         return services;
     }
+
+    /// <summary>
+    /// Never let a leftover/invalid Bearer token challenge anonymous auth endpoints.
+    /// </summary>
+    static JwtBearerEvents AnonymousAuthJwtEvents() => new()
+    {
+        OnMessageReceived = context =>
+        {
+            var path = context.Request.Path.Value ?? "";
+            if (DualAuthPassThrough.IsAnonymousAuthPath(path))
+                context.Token = null;
+            return Task.CompletedTask;
+        },
+        OnChallenge = context =>
+        {
+            var path = context.Request.Path.Value ?? "";
+            if (DualAuthPassThrough.IsAnonymousAuthPath(path))
+            {
+                // Endpoint handles its own 401 body (invalid_credentials, etc.)
+                context.HandleResponse();
+            }
+            return Task.CompletedTask;
+        }
+    };
 }


### PR DESCRIPTION
Fixes first POST /api/v1/auth/login returning 401 while a later refresh works.

- Ignore Bearer on anonymous auth routes (no JWT challenge)
- Re-sync SuperAdmin password hash from config
- Case-insensitive email login
- Force-clear stale session before login lock
