### PR TITLE
fix(admin): real data + skeleton loaders, remove mock UI data

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,9 +8,9 @@
     <Deterministic>true</Deterministic>
 
     <!-- Unified SemVer (see version.json + docs/ops/versioning.md) -->
-    <VersionPrefix>0.2.1</VersionPrefix>
+    <VersionPrefix>0.2.2</VersionPrefix>
     <Version>$(VersionPrefix)</Version>
-    <AssemblyVersion>0.2.1.0</AssemblyVersion>
+    <AssemblyVersion>0.2.2.0</AssemblyVersion>
     <FileVersion>$(VersionPrefix).0</FileVersion>
     <InformationalVersion>$(VersionPrefix)+$(SourceRevisionId)</InformationalVersion>
     <SourceRevisionId Condition="'$(SourceRevisionId)' == ''">local</SourceRevisionId>

--- a/apps/admin/app/dashboard/page.tsx
+++ b/apps/admin/app/dashboard/page.tsx
@@ -1,4 +1,299 @@
 'use client'
-import {motion} from 'framer-motion'; import {Activity,CheckCircle2,Send,Users,ArrowRight,Zap} from 'lucide-react'; import Link from 'next/link'; import {Button} from '@/components/ui/button'; import {Card,CardContent,CardHeader,CardTitle} from '@/components/ui/card'; import {StatCard} from '@/components/stat-card'; import {SectionCard} from '@/components/section-card'; import {Activity as ActivityList} from '@/components/activity'; import {DashboardChart} from '@/components/dashboard-chart'; import {Progress} from '@/components/ui/progress'
-const recent=[['OTP verification','push','Delivered','+98•••2214','1.2s'],['Payment successful','sms','Delivered','+98•••0871','1.8s'],['Invoice ready','email','Queued','user@domain.com','—'],['Security alert','push','Delivered','+98•••9920','0.9s']]
-export default function Dashboard(){return <div className="grid-bg min-h-full p-5 md:p-8"><div className="mx-auto max-w-[1500px]"><motion.div initial={{opacity:0,y:12}} animate={{opacity:1,y:0}} transition={{duration:.35}}><div className="mb-8 flex flex-col justify-between gap-5 md:flex-row md:items-center"><div><div className="mb-2 flex items-center gap-2 text-xs font-medium text-emerald-600"><span className="h-2 w-2 animate-pulse rounded-full bg-emerald-500"/>Live messaging plane</div><h1 className="text-3xl font-bold tracking-tight">Good morning, Admin</h1><p className="mt-2 text-sm text-muted-foreground">Here’s what’s happening across your notification infrastructure.</p></div><div className="flex gap-2"><Link href="/notifications"><Button variant="outline">View activity</Button></Link><Link href="/notifications"><Button><Send size={16}/>Send notification</Button></Link></div></div></motion.div><div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4"><StatCard label="Notifications sent" value="128,420" change="18.6%" icon={<Send size={18}/>}/><StatCard label="Delivery rate" value="98.72%" change="1.4%" icon={<CheckCircle2 size={18}/>}/><StatCard label="Active recipients" value="42.8K" change="8.2%" icon={<Users size={18}/>}/><StatCard label="Avg. delivery time" value="1.42s" change="12.4%" negative icon={<Zap size={18}/>}/></div><div className="mt-4 grid gap-4 xl:grid-cols-[1.6fr_1fr]"><SectionCard title="Message throughput" subtitle="Last 7 days · sent vs delivered" action={<div className="flex items-center gap-3 text-xs"><span className="flex items-center gap-1.5"><i className="h-2 w-2 rounded-full bg-primary"/>Sent</span><span className="flex items-center gap-1.5"><i className="h-2 w-2 rounded-full bg-emerald-500"/>Delivered</span></div>}><DashboardChart/></SectionCard><SectionCard title="Channel health" subtitle="Current provider availability"><div className="space-y-5"><div><div className="mb-2 flex justify-between text-sm"><span>Push</span><span className="font-medium">99.8%</span></div><Progress value={99.8}/></div><div><div className="mb-2 flex justify-between text-sm"><span>SMS</span><span className="font-medium">98.9%</span></div><Progress value={98.9}/></div><div><div className="mb-2 flex justify-between text-sm"><span>Email</span><span className="font-medium">99.6%</span></div><Progress value={99.6}/></div><div><div className="mb-2 flex justify-between text-sm"><span>Webhook</span><span className="font-medium">97.4%</span></div><Progress value={97.4}/></div></div><div className="mt-7 rounded-xl bg-muted/60 p-4"><div className="flex items-center gap-2 text-sm font-medium"><Activity size={16} className="text-primary"/>Messaging health</div><p className="mt-1 text-xs text-muted-foreground">No provider degradation detected in the last 30 minutes.</p></div></SectionCard></div><div className="mt-4 grid gap-4 xl:grid-cols-[1.35fr_.65fr]"><SectionCard title="Recent notifications" subtitle="Latest delivery events" action={<Link href="/notifications" className="flex items-center gap-1 text-xs font-medium text-primary">View all <ArrowRight size={13}/></Link>}><div className="overflow-x-auto"><table className="w-full min-w-[650px] text-sm"><thead className="text-left text-xs text-muted-foreground"><tr><th className="pb-3 font-medium">Template</th><th className="pb-3 font-medium">Channel</th><th className="pb-3 font-medium">Status</th><th className="pb-3 font-medium">Recipient</th><th className="pb-3 font-medium">Latency</th></tr></thead><tbody>{recent.map(r=><tr key={r[0]} className="border-t"><td className="py-3 font-medium">{r[0]}</td><td className="py-3 text-muted-foreground">{r[1]}</td><td className="py-3"><span className={'rounded-full px-2 py-1 text-[10px] font-medium '+(r[2]==='Delivered'?'bg-emerald-500/10 text-emerald-600':'bg-amber-500/10 text-amber-600')}>{r[2]}</span></td><td className="py-3 text-muted-foreground">{r[3]}</td><td className="py-3 text-muted-foreground">{r[4]}</td></tr>)}</tbody></table></div></SectionCard><SectionCard title="Activity" subtitle="Operational events"><ActivityList/></SectionCard></div></div></div>}
+
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { motion } from 'framer-motion'
+import { Activity, CheckCircle2, Send, Users, ArrowRight, Zap, AlertCircle } from 'lucide-react'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { StatCard } from '@/components/stat-card'
+import { SectionCard } from '@/components/section-card'
+import { Progress } from '@/components/ui/progress'
+import { Skeleton } from '@/components/ui/skeleton'
+import { flowApi } from '@/lib/api/flow'
+import { formatChannel, formatStatus } from '@/lib/ux/labels'
+
+function formatLag(ms?: number | null) {
+  if (ms == null || Number.isNaN(ms)) return '—'
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
+  return `${(ms / 60_000).toFixed(1)}m`
+}
+
+function statusTone(status: string) {
+  const s = status.toLowerCase()
+  if (['delivered', 'read'].includes(s)) return 'bg-emerald-500/10 text-emerald-600'
+  if (['failed', 'deadletter', 'rejected'].includes(s)) return 'bg-destructive/10 text-destructive'
+  if (['queued', 'scheduled'].includes(s)) return 'bg-amber-500/10 text-amber-600'
+  return 'bg-muted text-muted-foreground'
+}
+
+export default function Dashboard() {
+  const q = useQuery({
+    queryKey: ['notifications', 'flow', 'dashboard'],
+    queryFn: () => flowApi.snapshot(40),
+    refetchInterval: 15_000,
+  })
+
+  const snap = q.data
+  const loading = q.isLoading
+  const totalInView =
+    (snap?.queued ?? 0) + (snap?.sending ?? 0) + (snap?.delivered ?? 0) + (snap?.failed ?? 0)
+  const deliveredRate =
+    totalInView > 0 ? ((snap?.delivered ?? 0) / totalInView) * 100 : null
+
+  const channelShares = useMemo(() => {
+    const items = snap?.items ?? []
+    if (!items.length) return [] as { channel: string; pct: number; count: number }[]
+    const counts = new Map<string, number>()
+    for (const it of items) {
+      const c = (it.channel || 'unknown').toLowerCase()
+      counts.set(c, (counts.get(c) ?? 0) + 1)
+    }
+    const total = items.length
+    return Array.from(counts.entries())
+      .map(([channel, count]) => ({ channel, count, pct: (count / total) * 100 }))
+      .sort((a, b) => b.count - a.count)
+  }, [snap])
+
+  const recent = snap?.items?.slice(0, 8) ?? []
+  const events = snap?.events?.slice(0, 8) ?? []
+
+  return (
+    <div className="grid-bg min-h-full p-5 md:p-8">
+      <div className="mx-auto max-w-[1500px]">
+        <motion.div initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.35 }}>
+          <div className="mb-8 flex flex-col justify-between gap-5 md:flex-row md:items-center">
+            <div>
+              <div className="mb-2 flex items-center gap-2 text-xs font-medium text-emerald-600">
+                <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-500" />
+                Live messaging plane
+              </div>
+              <h1 className="text-3xl font-bold tracking-tight">Overview</h1>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Live delivery snapshot for this tenant — queue, in-flight, delivered, and failures.
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <Link href="/workflows/live">
+                <Button variant="outline">Delivery flow</Button>
+              </Link>
+              <Link href="/notifications">
+                <Button>
+                  <Send size={16} /> Send notification
+                </Button>
+              </Link>
+            </div>
+          </div>
+        </motion.div>
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {loading ? (
+            <>
+              {[0, 1, 2, 3].map((i) => (
+                <Skeleton key={i} className="h-[120px] w-full rounded-xl" />
+              ))}
+            </>
+          ) : (
+            <>
+              <StatCard
+                label="In view (sample)"
+                value={String(totalInView)}
+                change={`${snap?.queued ?? 0} queued`}
+                icon={<Send size={18} />}
+              />
+              <StatCard
+                label="Delivery rate"
+                value={deliveredRate == null ? '—' : `${deliveredRate.toFixed(1)}%`}
+                change={`${snap?.delivered ?? 0} delivered`}
+                icon={<CheckCircle2 size={18} />}
+              />
+              <StatCard
+                label="Failed / dead"
+                value={String(snap?.failed ?? 0)}
+                change={`${snap?.sending ?? 0} sending`}
+                negative={(snap?.failed ?? 0) > 0}
+                icon={<Users size={18} />}
+              />
+              <StatCard
+                label="Avg. latency"
+                value={formatLag(snap?.avgLatencyMs)}
+                change="from flow sample"
+                icon={<Zap size={18} />}
+              />
+            </>
+          )}
+        </div>
+
+        <div className="mt-4 grid gap-4 xl:grid-cols-[1.6fr_1fr]">
+          <SectionCard title="Channel mix" subtitle="Share of recent messages by channel">
+            {loading ? (
+              <div className="space-y-4">
+                {[0, 1, 2].map((i) => (
+                  <Skeleton key={i} className="h-8 w-full" />
+                ))}
+              </div>
+            ) : channelShares.length === 0 ? (
+              <p className="py-10 text-center text-sm text-muted-foreground">No messages in the current sample.</p>
+            ) : (
+              <div className="space-y-5">
+                {channelShares.map((c) => (
+                  <div key={c.channel}>
+                    <div className="mb-2 flex justify-between text-sm">
+                      <span className="capitalize">{formatChannel(c.channel)}</span>
+                      <span className="font-medium">
+                        {c.pct.toFixed(0)}% · {c.count}
+                      </span>
+                    </div>
+                    <Progress value={c.pct} />
+                  </div>
+                ))}
+              </div>
+            )}
+          </SectionCard>
+
+          <SectionCard title="Pipeline health" subtitle="Live stage counts">
+            {loading ? (
+              <div className="space-y-4">
+                {[0, 1, 2, 3].map((i) => (
+                  <Skeleton key={i} className="h-8 w-full" />
+                ))}
+              </div>
+            ) : (
+              <div className="space-y-5">
+                {(
+                  [
+                    ['Queued', snap?.queued ?? 0],
+                    ['Sending', snap?.sending ?? 0],
+                    ['Delivered', snap?.delivered ?? 0],
+                    ['Failed', snap?.failed ?? 0],
+                  ] as const
+                ).map(([label, value]) => (
+                  <div key={label}>
+                    <div className="mb-2 flex justify-between text-sm">
+                      <span>{label}</span>
+                      <span className="font-medium">{value}</span>
+                    </div>
+                    <Progress
+                      value={totalInView ? (value / totalInView) * 100 : 0}
+                    />
+                  </div>
+                ))}
+                <div className="mt-2 rounded-xl bg-muted/60 p-4">
+                  <div className="flex items-center gap-2 text-sm font-medium">
+                    <Activity size={16} className="text-primary" />
+                    Messaging health
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {(snap?.failed ?? 0) > 0
+                      ? `${snap?.failed} failure(s) in the current sample — check the delivery flow log.`
+                      : 'No failures in the current sample.'}
+                  </p>
+                </div>
+              </div>
+            )}
+          </SectionCard>
+        </div>
+
+        <div className="mt-4 grid gap-4 xl:grid-cols-[1.35fr_.65fr]">
+          <SectionCard
+            title="Recent notifications"
+            subtitle="Latest items from the live flow sample"
+            action={
+              <Link href="/workflows/live" className="flex items-center gap-1 text-xs font-medium text-primary">
+                Open flow <ArrowRight size={13} />
+              </Link>
+            }
+          >
+            {loading ? (
+              <div className="space-y-3">
+                {[0, 1, 2, 3, 4].map((i) => (
+                  <Skeleton key={i} className="h-10 w-full" />
+                ))}
+              </div>
+            ) : recent.length === 0 ? (
+              <p className="py-10 text-center text-sm text-muted-foreground">No recent notifications.</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[650px] text-sm">
+                  <thead className="text-left text-xs text-muted-foreground">
+                    <tr>
+                      <th className="pb-3 font-medium">Recipient</th>
+                      <th className="pb-3 font-medium">Channel</th>
+                      <th className="pb-3 font-medium">Status</th>
+                      <th className="pb-3 font-medium">Provider</th>
+                      <th className="pb-3 font-medium">Latency</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {recent.map((r) => (
+                      <tr key={r.id} className="border-t">
+                        <td className="py-3 font-medium">{r.recipient}</td>
+                        <td className="py-3 text-muted-foreground">{formatChannel(r.channel)}</td>
+                        <td className="py-3">
+                          <span className={`rounded-full px-2 py-1 text-[10px] font-medium ${statusTone(r.status)}`}>
+                            {formatStatus(r.status)}
+                          </span>
+                        </td>
+                        <td className="py-3 text-muted-foreground">{r.providerId || 'default'}</td>
+                        <td className="py-3 text-muted-foreground">{formatLag(r.latencyMs)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </SectionCard>
+
+          <SectionCard title="Activity" subtitle="Humanized delivery events">
+            {loading ? (
+              <div className="space-y-4">
+                {[0, 1, 2, 3].map((i) => (
+                  <div key={i} className="flex gap-3">
+                    <Skeleton className="h-8 w-8 rounded-lg" />
+                    <div className="flex-1 space-y-2">
+                      <Skeleton className="h-4 w-3/4" />
+                      <Skeleton className="h-3 w-1/2" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : events.length === 0 ? (
+              <p className="py-10 text-center text-sm text-muted-foreground">No events yet.</p>
+            ) : (
+              <div className="space-y-5">
+                {events.map((ev, i) => {
+                  const icon =
+                    ev.severity === 'success' ? (
+                      <CheckCircle2 size={16} className="text-emerald-500" />
+                    ) : ev.severity === 'error' || ev.severity === 'warn' ? (
+                      <AlertCircle size={16} className="text-amber-500" />
+                    ) : (
+                      <Activity size={16} className="text-primary" />
+                    )
+                  return (
+                    <div key={`${ev.at}-${i}`} className="flex gap-3">
+                      <div className="mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-muted">{icon}</div>
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm font-medium leading-snug">{ev.message}</div>
+                        <div className="mt-1 text-[10px] text-muted-foreground">
+                          {new Date(ev.at).toLocaleString()}
+                        </div>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </SectionCard>
+        </div>
+
+        {q.isError && (
+          <p className="mt-4 text-sm text-destructive">
+            Could not load live snapshot. Check API auth and tenant context.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/admin/app/templates/page.tsx
+++ b/apps/admin/app/templates/page.tsx
@@ -8,21 +8,11 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
 import { TemplateEditor } from '@/components/template-editor'
 import { useTemplates } from '@/hooks/use-templates'
-import { templates } from '@/lib/mock'
 import { formatChannel, templateTitle } from '@/lib/ux/labels'
 import type { TemplateDefinition } from '@/types/api'
-
-const fallback: TemplateDefinition[] = templates.map((x) => ({
-  key: x[0],
-  subject: x[1],
-  channel: x[2],
-  locale: x[3],
-  version: Number(x[4]) || 1,
-  isActive: x[5] === 'Active',
-  body: x[1],
-}))
 
 export default function TemplatesPage() {
   const [channel, setChannel] = useState('all')
@@ -32,13 +22,15 @@ export default function TemplatesPage() {
   const result = useTemplates(channel === 'all' ? undefined : channel)
 
   const rows = useMemo(() => {
-    const data = result.data?.length ? result.data : fallback
+    const data = result.data ?? []
     return data.filter(
       (x) =>
         (channel === 'all' || x.channel === channel) &&
         `${templateTitle(x)} ${x.key} ${x.locale}`.toLowerCase().includes(q.toLowerCase()),
     )
   }, [result.data, channel, q])
+
+  const loading = result.isLoading
 
   const edit = (x: TemplateDefinition) => {
     setSelected(x)
@@ -65,9 +57,19 @@ export default function TemplatesPage() {
         />
 
         <div className="mb-5 grid gap-3 md:grid-cols-3">
-          <Metric icon={FileText} label="Templates" value={String(rows.length)} />
-          <Metric icon={Sparkles} label="Active" value={String(rows.filter((x) => x.isActive !== false).length)} />
-          <Metric icon={SlidersHorizontal} label="Channels" value={String(new Set(rows.map((x) => x.channel)).size)} />
+          {loading ? (
+            <>
+              {[0, 1, 2].map((i) => (
+                <Skeleton key={i} className="h-[72px] w-full rounded-xl" />
+              ))}
+            </>
+          ) : (
+            <>
+              <Metric icon={FileText} label="Templates" value={String(rows.length)} />
+              <Metric icon={Sparkles} label="Active" value={String(rows.filter((x) => x.isActive !== false).length)} />
+              <Metric icon={SlidersHorizontal} label="Channels" value={String(new Set(rows.map((x) => x.channel)).size)} />
+            </>
+          )}
         </div>
 
         <Card className="overflow-hidden">
@@ -108,36 +110,50 @@ export default function TemplatesPage() {
             </div>
 
             <div>
-              {rows.map((x, i) => (
-                <motion.button
-                  key={`${x.key}-${x.channel}-${x.locale}`}
-                  type="button"
-                  onClick={() => edit(x)}
-                  initial={{ opacity: 0, y: 6 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: i * 0.025 }}
-                  className="grid w-full gap-2 border-b px-5 py-4 text-left transition hover:bg-muted/30 md:grid-cols-[1.6fr_.7fr_.7fr_.45fr_.5fr_auto] md:items-center"
-                >
-                  <div>
-                    <div className="text-sm font-semibold">{templateTitle(x)}</div>
-                    <div className="mt-1 truncate text-xs text-muted-foreground">{x.subject || 'No subject'}</div>
-                  </div>
-                  <div>
-                    <Badge variant="outline">{formatChannel(x.channel)}</Badge>
-                  </div>
-                  <div className="text-sm text-muted-foreground">{x.locale}</div>
-                  <div className="text-sm">v{x.version ?? 1}</div>
-                  <div>
-                    <Badge variant={x.isActive === false ? 'default' : 'success'}>
-                      {x.isActive === false ? 'Inactive' : 'Active'}
-                    </Badge>
-                  </div>
-                  <div className="text-xs text-muted-foreground">Edit</div>
-                </motion.button>
-              ))}
-              {!rows.length && (
+              {loading && (
+                <div className="space-y-0">
+                  {[0, 1, 2, 3, 4, 5].map((i) => (
+                    <div key={i} className="border-b px-5 py-4">
+                      <Skeleton className="h-12 w-full" />
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {!loading &&
+                rows.map((x, i) => (
+                  <motion.button
+                    key={`${x.key}-${x.channel}-${x.locale}`}
+                    type="button"
+                    onClick={() => edit(x)}
+                    initial={{ opacity: 0, y: 6 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: i * 0.025 }}
+                    className="grid w-full gap-2 border-b px-5 py-4 text-left transition hover:bg-muted/30 md:grid-cols-[1.6fr_.7fr_.7fr_.45fr_.5fr_auto] md:items-center"
+                  >
+                    <div>
+                      <div className="text-sm font-semibold">{templateTitle(x)}</div>
+                      <div className="mt-1 truncate text-xs text-muted-foreground">{x.subject || 'No subject'}</div>
+                    </div>
+                    <div>
+                      <Badge variant="outline">{formatChannel(x.channel)}</Badge>
+                    </div>
+                    <div className="text-sm text-muted-foreground">{x.locale}</div>
+                    <div className="text-sm">v{x.version ?? 1}</div>
+                    <div>
+                      <Badge variant={x.isActive === false ? 'default' : 'success'}>
+                        {x.isActive === false ? 'Inactive' : 'Active'}
+                      </Badge>
+                    </div>
+                    <div className="text-xs text-muted-foreground">Edit</div>
+                  </motion.button>
+                ))}
+
+              {!loading && !rows.length && (
                 <div className="p-12 text-center text-sm text-muted-foreground">
-                  No templates match your search. Try another channel or create a new template.
+                  {result.isError
+                    ? 'Could not load templates. Check API auth and tenant.'
+                    : 'No templates yet. Create one to get started.'}
                 </div>
               )}
             </div>

--- a/apps/admin/components/activity.tsx
+++ b/apps/admin/components/activity.tsx
@@ -1,3 +1,39 @@
-import {CheckCircle2,Clock3,AlertCircle,Send} from 'lucide-react';
-const items=[['Notification delivered','OTP login notification sent to +98•••2214','2 min ago','success'],['Campaign processing','Black Friday campaign reached 72%','8 min ago','info'],['Webhook retry','delivery.failed endpoint retry scheduled','14 min ago','warning'],['Workflow completed','payment.received → email → push','22 min ago','success']]
-export function Activity(){return <div className="space-y-5">{items.map(([title,desc,time,type])=><div key={title} className="flex gap-3"><div className="mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-muted">{type==='success'?<CheckCircle2 size={16} className="text-emerald-500"/>:type==='warning'?<AlertCircle size={16} className="text-amber-500"/>:<Clock3 size={16} className="text-primary"/>}</div><div className="min-w-0 flex-1"><div className="text-sm font-medium">{title}</div><div className="truncate text-xs text-muted-foreground">{desc}</div><div className="mt-1 text-[10px] text-muted-foreground">{time}</div></div></div>)}</div>}
+'use client'
+
+import { CheckCircle2, Clock3, AlertCircle } from 'lucide-react'
+
+export type ActivityItem = {
+  title: string
+  description: string
+  time: string
+  type?: 'success' | 'warning' | 'info'
+}
+
+export function Activity({ items }: { items: ActivityItem[] }) {
+  if (!items.length) {
+    return <p className="py-8 text-center text-sm text-muted-foreground">No activity yet.</p>
+  }
+
+  return (
+    <div className="space-y-5">
+      {items.map((item) => (
+        <div key={`${item.title}-${item.time}`} className="flex gap-3">
+          <div className="mt-0.5 grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-muted">
+            {item.type === 'success' ? (
+              <CheckCircle2 size={16} className="text-emerald-500" />
+            ) : item.type === 'warning' ? (
+              <AlertCircle size={16} className="text-amber-500" />
+            ) : (
+              <Clock3 size={16} className="text-primary" />
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-medium">{item.title}</div>
+            <div className="truncate text-xs text-muted-foreground">{item.description}</div>
+            <div className="mt-1 text-[10px] text-muted-foreground">{item.time}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/admin/components/dashboard-chart.tsx
+++ b/apps/admin/components/dashboard-chart.tsx
@@ -1,4 +1,16 @@
 'use client'
-import {AreaChart,Area,XAxis,YAxis,Tooltip,ResponsiveContainer} from 'recharts'
-const data=[{d:'Mon',sent:18,delivered:16},{d:'Tue',sent:25,delivered:23},{d:'Wed',sent:21,delivered:20},{d:'Thu',sent:34,delivered:31},{d:'Fri',sent:29,delivered:27},{d:'Sat',sent:41,delivered:38},{d:'Sun',sent:47,delivered:44}]
-export function DashboardChart(){return <div className="h-[290px] w-full"><ResponsiveContainer width="100%" height="100%"><AreaChart data={data}><defs><linearGradient id="sent" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stopColor="hsl(250 83% 62%)" stopOpacity={.25}/><stop offset="100%" stopColor="hsl(250 83% 62%)" stopOpacity={0}/></linearGradient></defs><XAxis dataKey="d" axisLine={false} tickLine={false} tick={{fontSize:11,fill:'#94a3b8'}}/><YAxis axisLine={false} tickLine={false} tick={{fontSize:11,fill:'#94a3b8'}}/><Tooltip contentStyle={{borderRadius:12,border:'1px solid #e2e8f0',boxShadow:'0 12px 30px rgba(15,23,42,.1)'}}/><Area type="monotone" dataKey="sent" stroke="hsl(250 83% 62%)" strokeWidth={2.5} fill="url(#sent)"/><Area type="monotone" dataKey="delivered" stroke="#10b981" strokeWidth={2} fill="transparent"/></AreaChart></ResponsiveContainer></div>}
+
+/**
+ * Throughput chart is disabled until a real time-series metrics endpoint exists.
+ * Do not invent daily series on the client.
+ */
+export function DashboardChart({ hasData = false }: { hasData?: boolean }) {
+  if (!hasData) {
+    return (
+      <div className="flex h-[290px] w-full items-center justify-center rounded-xl border border-dashed text-sm text-muted-foreground">
+        No throughput series available yet
+      </div>
+    )
+  }
+  return null
+}

--- a/apps/admin/components/ui/skeleton.tsx
+++ b/apps/admin/components/ui/skeleton.tsx
@@ -1,0 +1,10 @@
+import { cn } from '@/lib/utils'
+
+export function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('animate-pulse rounded-md bg-muted', className)}
+      {...props}
+    />
+  )
+}

--- a/apps/admin/lib/mock.ts
+++ b/apps/admin/lib/mock.ts
@@ -1,3 +1,6 @@
-export const notifications=[['N-8F2A','OTP verification','push','Delivered','+98•••2214','1.2s'],['N-8F29','Payment successful','sms','Delivered','+98•••0871','1.8s'],['N-8F28','Invoice ready','email','Queued','user@domain.com','—'],['N-8F27','Security alert','push','Delivered','+98•••9920','0.9s'],['N-8F26','Welcome message','email','Failed','hello@acme.io','3.1s'],['N-8F25','Password reset','sms','Delivered','+98•••1142','1.4s']]
-export const campaigns=[['CMP-1042','Black Friday 2026','email + push','Running','72%','42,800'],['CMP-1041','Monthly statement','email','Completed','100%','18,420'],['CMP-1039','Security awareness','sms','Scheduled','0%','8,400'],['CMP-1037','New feature launch','push','Draft','—','—']]
-export const templates=[['payment.success','Payment successful','email','en-US','v12','Active'],['otp.login','Login verification code','sms','fa-IR','v8','Active'],['order.shipped','Your order shipped','push','en-US','v5','Active'],['security.alert','Security alert','email','en-US','v3','Inactive']]
+/**
+ * Intentionally empty.
+ * Admin UI must not render placeholder/mock rows.
+ * Use TanStack Query + Skeleton while loading, then real API data or empty state.
+ */
+export {}

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.1",
+  "version": "0.2.2",
   "scheme": "semver",
   "product": "NotificationHub",
   "tagPattern": "vMAJOR.MINOR.PATCH"


### PR DESCRIPTION
## Problem
`/dashboard` (and templates fallback) showed hardcoded fake numbers and rows. That is unacceptable for an operations panel.

## Solution
- **Dashboard** loads live data from `GET /api/v1/notifications/flow` (queued / sending / delivered / failed, recent items, humanized events).
- While loading → **Skeleton** placeholders only. Never invent rows.
- Empty states when sample is empty; error message on API failure.
- **Templates**: removed `lib/mock` fallback; skeleton list while `useTemplates` is loading.
- `Activity` now requires real `items`; no internal mock list.
- Chart no longer draws fake Mon–Sun series (empty until a real metrics API exists).
- `lib/mock.ts` emptied.
- Version **0.2.1 → 0.2.2** (PATCH).

## Git flow
Branch from `dev`, PR only — no direct push to `dev`.

## Follow-up
Other list pages (campaigns, devices, …) should be audited the same way if any still hardcode sample rows.